### PR TITLE
Rich Scala collection-like API for `TypedColumn`

### DIFF
--- a/src/main/scala/com/github/codelionx/dodo/types/TypedColumn.scala
+++ b/src/main/scala/com/github/codelionx/dodo/types/TypedColumn.scala
@@ -57,9 +57,13 @@ trait TypedColumn[T <: Any]
     override def result(): TypedColumn[T] = internalBuilder.toTypedColumn
 
     override def +=(elem: T): BuilderAdapter.this.type = {
-      if(elem == null)
+      if (elem == null)
         internalBuilder.append(null)
       else
+        /* TODO: unefficient as we convert value to string and parse it afterwards in the builder.
+         * This method is called for all elements if we traverse it (e.g. with `.map` or `.reduce` and `TypedColumn` as
+         * target collection).
+         */
         internalBuilder.append(elem.toString)
       this
     }

--- a/src/main/scala/com/github/codelionx/dodo/types/TypedColumn.scala
+++ b/src/main/scala/com/github/codelionx/dodo/types/TypedColumn.scala
@@ -57,14 +57,7 @@ trait TypedColumn[T <: Any]
     override def result(): TypedColumn[T] = internalBuilder.toTypedColumn
 
     override def +=(elem: T): BuilderAdapter.this.type = {
-      if (elem == null)
-        internalBuilder.append(null)
-      else
-        /* TODO: unefficient as we convert value to string and parse it afterwards in the builder.
-         * This method is called for all elements if we traverse it (e.g. with `.map` or `.reduce` and `TypedColumn` as
-         * target collection).
-         */
-        internalBuilder.append(elem.toString)
+      internalBuilder += elem
       this
     }
   }

--- a/src/main/scala/com/github/codelionx/dodo/types/TypedColumnArrayLike.scala
+++ b/src/main/scala/com/github/codelionx/dodo/types/TypedColumnArrayLike.scala
@@ -1,0 +1,38 @@
+package com.github.codelionx.dodo.types
+
+
+/**
+  * Enriches [[com.github.codelionx.dodo.types.TypedColumnBase]]s with an array-like API.
+  */
+trait TypedColumnArrayLike[T] {
+  self: TypedColumnBase[T] =>
+
+  /**
+    * Returns the element on `i`^th^ position.
+    *
+    * Indices start at `0`; `xs.apply(0)` is the first element of array `xs`.
+    * Note the indexing syntax `xs(i)` is a shorthand for `xs.apply(i)`.
+    *
+    * @param i the index
+    * @return the element at the given index
+    * @throws ArrayIndexOutOfBoundsException if `i < 0` or `length <= i`
+    */
+  def apply(i: Int): T = array.apply(i)
+
+  /**
+    * Updates the element at given i.
+    *
+    * Indices start at `0`; `xs.update(i, x)` replaces the i^th^ element in the array.
+    * Note the syntax `xs(i) = x` is a shorthand for `xs.update(i, x)`.
+    *
+    * @param i the index
+    * @param x the value to be written at index `i`
+    * @throws ArrayIndexOutOfBoundsException if `i < 0` or `length <= i`
+    */
+  def update(i: Int, x: T): Unit = array.update(i, x)
+
+  /**
+    * @return length of the column
+    */
+  def length: Int = array.length
+}

--- a/src/main/scala/com/github/codelionx/dodo/types/TypedColumnBuilder.scala
+++ b/src/main/scala/com/github/codelionx/dodo/types/TypedColumnBuilder.scala
@@ -39,6 +39,14 @@ final class TypedColumnBuilder[T <: Any : ClassTag] private(dataType: DataType[T
     */
   def append(elems: String*): Unit = buffer.append(elems.map(dataType.parse): _*)
 
+  /**
+    * Add a single element to this builder.
+    */
+  def +=(elem: T): TypedColumnBuilder.this.type = {
+    buffer += elem
+    this
+  }
+
   private case class TypedColumnImpl(dataType: DataType[T], array: Array[T]) extends TypedColumn[T]
 
 }

--- a/src/main/scala/com/github/codelionx/dodo/types/TypedColumnBuilder.scala
+++ b/src/main/scala/com/github/codelionx/dodo/types/TypedColumnBuilder.scala
@@ -25,6 +25,8 @@ final class TypedColumnBuilder[T <: Any : ClassTag] private(dataType: DataType[T
 
   private val buffer: ArrayBuffer[T] = ArrayBuffer.empty
 
+  def clear(): Unit = buffer.clear()
+
   /**
     * Returns the [[com.github.codelionx.dodo.types.TypedColumn]] instance with all the parsed cell data.
     */
@@ -37,13 +39,6 @@ final class TypedColumnBuilder[T <: Any : ClassTag] private(dataType: DataType[T
     */
   def append(elems: String*): Unit = buffer.append(elems.map(dataType.parse): _*)
 
-  private case class TypedColumnImpl(dataType: DataType[T], arr: Array[T]) extends TypedColumn[T] {
-
-    override def toArray: Array[T] = arr
-
-    override def apply(i: Int): T = arr.apply(i)
-
-    override def update(i: Int, x: T): Unit = arr.update(i, x)
-  }
+  private case class TypedColumnImpl(dataType: DataType[T], array: Array[T]) extends TypedColumn[T]
 
 }

--- a/src/main/scala/com/github/codelionx/dodo/types/TypedColumnSeqLike.scala
+++ b/src/main/scala/com/github/codelionx/dodo/types/TypedColumnSeqLike.scala
@@ -1,0 +1,22 @@
+package com.github.codelionx.dodo.types
+
+import scala.collection.{SeqLike, mutable}
+
+
+/**
+  * Enriches [[com.github.codelionx.dodo.types.TypedColumnBase]]s with a seq-like API, similar to
+  * [[scala.collection.SeqLike]]
+  */
+trait TypedColumnSeqLike[T, +Repr] extends SeqLike[T, Repr] {
+  self: TypedColumnBase[T] with TypedColumnArrayLike[T] =>
+
+  // already defined in TypedColumnArrayLike
+//  override def length: Int = array.length
+//  override def apply(idx: Int): T = array.apply(idx)
+
+  override def seq: Seq[T] = array.seq
+
+  override def iterator: Iterator[T] = array.iterator
+
+  override protected def newBuilder: mutable.Builder[T, Repr]
+}


### PR DESCRIPTION
### Proposed Changes

Enriches our `TypedColumn` value class with an array- and sequence-like API. The usage is familiar to the Scala collections API.

- Refactoring of `TypedColumn` and `TypedColumnBuilder`
  - `TypedColumn` now is a combination of the base class and the mixin-traits
  - the `TypedColumnImpl` just implements the `dataType` and `array` members via a case class, other functionality is provided by the mixins
- introduction of mixin `TypedColumnArrayLike` for all methods on arrays
- introduction of mixin `TypedColumnSeqLike` for all methods on sequences (see ref. below)
- we now need a adapter-implementation for the builder to satisfy the `scala.collection.mutable.Builder` interface used in `TypedColumnSeqLike`

_We can not extend `Array` as it is declared `final`, so this works around it by wrapping the array in our own rich collection type._

**Example usage of `TypedColumn`s:**
```scala
val builder = TypedColumnBuilder(DoubleType)
builder.append("2.3")
builder.append("0.4")
builder.append("0.1")
builder.append("0.4")

val col: TypedColumn[Double] = builder.toTypedColumn
col.filter(_ > 0.5) // TypedColumn(DoubleType, (2.3))
col.distinct  // TypedColumn(DoubleType, (2.3, 0.4, 0.1))
col.map("d" + _).toSeq // Seq("d2.3", "d0.4", "d0.1", "d0.4"))
```

**Helpful information:**
- [Scala self-types](https://docs.scala-lang.org/tour/self-types.html)
- [`scala.collection.SeqLike` spec](https://www.scala-lang.org/api/current/scala/collection/SeqLike.html)

### Type of Changes

- [x] Feature
- [ ] Bug fix
- [x] Refactoring

