### PR TITLE
More ways to build TypedColumns and more tests

### DIFF
--- a/src/main/scala/com/github/codelionx/dodo/types/TypedColumn.scala
+++ b/src/main/scala/com/github/codelionx/dodo/types/TypedColumn.scala
@@ -1,5 +1,7 @@
 package com.github.codelionx.dodo.types
 
+import java.util.Objects
+
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
@@ -37,6 +39,18 @@ trait TypedColumn[T <: Any]
     with TypedColumnSeqLike[T, TypedColumn[T]] {
 
   override protected def newBuilder: mutable.Builder[T, TypedColumn[T]] = new BuilderAdapter
+
+
+  // overrides of [[java.lang.Object]]
+
+  override def hashCode(): Int = Objects.hash(dataType, array.toSeq)
+
+  override def canEqual(o: Any): Boolean = o.isInstanceOf[TypedColumn[T]]
+
+  override def equals(o: Any): Boolean = o match {
+    case o: TypedColumn[T] => o.canEqual(this) && this.hashCode() == o.hashCode()
+    case _ => false
+  }
 
   override def toString: String =
     s"""|Column of $dataType:

--- a/src/main/scala/com/github/codelionx/dodo/types/TypedColumnBuilder.scala
+++ b/src/main/scala/com/github/codelionx/dodo/types/TypedColumnBuilder.scala
@@ -13,6 +13,32 @@ object TypedColumnBuilder {
     */
   def apply[T <: Any : ClassTag](dataType: DataType[T]): TypedColumnBuilder[T] = new TypedColumnBuilder(dataType)
 
+  /**
+    * Creates a new [[com.github.codelionx.dodo.types.TypedColumn]] from the supplied `elems` parsing them to the
+    * supplied `dataType`.
+    *
+    * @param dataType specifies the column's type
+    * @param elems content of the column, will be parsed to the `dataType`
+    */
+  def withType[T <: Any](dataType: DataType[T])(elems: String*)(implicit ev: ClassTag[T]): TypedColumn[T] = {
+    val builder = new TypedColumnBuilder(dataType)
+    builder.append(elems: _*)
+    builder.toTypedColumn
+  }
+
+  /**
+    * Creates a new [[com.github.codelionx.dodo.types.TypedColumn]] from the supplied `elems`.
+    *
+    * @param elems content of the column
+    */
+  def from[T <: Any](elems: T*)(implicit ev: ClassTag[T]): TypedColumn[T] = {
+    val tpe = DataType.of[T]
+    val builder = new TypedColumnBuilder[T](tpe)
+    elems.foreach{ elem =>
+      builder += elem
+    }
+    builder.toTypedColumn
+  }
 }
 
 /**
@@ -44,7 +70,7 @@ final class TypedColumnBuilder[T <: Any : ClassTag] private(dataType: DataType[T
     */
   def +=(elem: T): TypedColumnBuilder.this.type = {
     buffer += elem
-    thi
+    this
   }
 
   private case class TypedColumnImpl(dataType: DataType[T], array: Array[T]) extends TypedColumn[T]

--- a/src/test/scala/com/github/codelionx/dodo/types/DataTypeSpec.scala
+++ b/src/test/scala/com/github/codelionx/dodo/types/DataTypeSpec.scala
@@ -1,0 +1,64 @@
+package com.github.codelionx.dodo.types
+
+import java.time.{LocalDateTime, ZonedDateTime}
+
+import org.scalatest.{Matchers, WordSpec}
+
+
+class DataTypeSpec extends WordSpec with Matchers {
+
+  "The DataType companion object" should {
+
+    "support ZonedDateTime in the factory method" in {
+      val dt = DataType.of[ZonedDateTime]
+      dt shouldEqual ZonedDateType(DateType.DEFAULT_FORMAT)
+    }
+
+    "support LocalDateTime in the factory method" in {
+      val dt = DataType.of[LocalDateTime]
+      dt shouldEqual LocalDateType(DateType.DEFAULT_FORMAT)
+    }
+
+    "support Double in the factory method" in {
+      val dt = DataType.of[Double]
+      dt shouldEqual DoubleType
+    }
+
+    "support Long in the factory method" in {
+      val dt = DataType.of[Long]
+      dt shouldEqual LongType
+    }
+
+    "support String in the factory method" in {
+      val dt = DataType.of[String]
+      dt shouldEqual StringType
+    }
+
+    "support Null in the factory method" in {
+      val dt = DataType.of[Null]
+      dt shouldEqual NullType
+    }
+
+    "throw an error if the type is not supported" in {
+      an[IllegalArgumentException] shouldBe thrownBy {
+        DataType.of[Int]
+      }
+      an[IllegalArgumentException] shouldBe thrownBy {
+        DataType.of[Float]
+      }
+      an[IllegalArgumentException] shouldBe thrownBy {
+        DataType.of[Char]
+      }
+      an[IllegalArgumentException] shouldBe thrownBy {
+        DataType.of[Boolean]
+      }
+      an[IllegalArgumentException] shouldBe thrownBy {
+        DataType.of[Any]
+      }
+      case class Test(a: Int)
+      an[IllegalArgumentException] shouldBe thrownBy {
+        DataType.of[Test]
+      }
+    }
+  }
+}

--- a/src/test/scala/com/github/codelionx/dodo/types/TypedColumnBuilderSpec.scala
+++ b/src/test/scala/com/github/codelionx/dodo/types/TypedColumnBuilderSpec.scala
@@ -1,0 +1,32 @@
+package com.github.codelionx.dodo.types
+
+import org.scalatest.{Matchers, WordSpec}
+
+
+class TypedColumnBuilderSpec extends WordSpec with Matchers {
+
+  "The TypedColumnBuilder factory methods" should {
+
+    "produce the same typed columns" in {
+      val columnValues = Seq(25.1, 0.4, 1.2, 123.00001)
+      val tpe = DoubleType
+
+      val builder = TypedColumnBuilder(tpe)
+      builder.append(columnValues.map(_.toString): _*)
+      val longBuilderResult = builder.toTypedColumn
+      
+      val explicitTypedResult = TypedColumnBuilder.withType(tpe)(columnValues.map(_.toString): _*)
+      val implicitTypedResult = TypedColumnBuilder.from(columnValues: _*)
+
+      // check equality
+      longBuilderResult shouldEqual explicitTypedResult
+      longBuilderResult shouldEqual implicitTypedResult
+      explicitTypedResult shouldEqual implicitTypedResult
+
+      // check contents
+      longBuilderResult.dataType shouldEqual DoubleType
+      longBuilderResult.array.toSeq shouldEqual columnValues
+    }
+  }
+
+}


### PR DESCRIPTION
### Proposed Changes

- Factory method to create a `DataType` from a scala type:
  ```scala
  val tpe = DataType.of[Long]
  tpe == LongType // true
  ```
- Factory methods to create `TypedColumn`s with literals:
  ```scala
  val col1 = TypedColumnBuilder.withType(DoubleType)(2.3, 14.0, .5)
  val col2 = TypedColumnBuilder.from(2.3, 14.0, .5)
  col1 equals col2 // true
  ```
- Tests for the new factory methods

### Type of Changes

- [ ] Feature
- [ ] Bug fix
- [x] Refactoring

