### PR TITLE
Feature/same results as oc ddiscover

### DIFF
--- a/src/main/resources/dodo.conf
+++ b/src/main/resources/dodo.conf
@@ -1,5 +1,5 @@
 com.github.codelionx.dodo {
   # for our config
-  input-file = "data/iris_const.csv"
+  input-file = "data/test.csv"
   output-file = "data/results.txt"
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -4,6 +4,9 @@ com.github.codelionx.dodo {
   // number of workers to spawn
   workers = 1
 
+  // print only some found OCDs for better comparability to ocddiscover
+  ocd-comparability = true
+
   parsing {
     // number of rows to parse before the type inferrer decides on a fixed data type for each column
     inferring-rows = 20

--- a/src/main/scala/com/github/codelionx/dodo/Settings.scala
+++ b/src/main/scala/com/github/codelionx/dodo/Settings.scala
@@ -47,6 +47,8 @@ class Settings(config: Config) extends Extension {
 
   val workers: Int = config.getInt(s"$namespace.workers")
 
+  val ocdComparability: Boolean = config.getBoolean(s"$namespace.ocd-comparability")
+
   val parsing: ParsingSettings = new ParsingSettings(config, namespace)
 
 }

--- a/src/main/scala/com/github/codelionx/dodo/actors/Worker.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/Worker.scala
@@ -1,6 +1,7 @@
 package com.github.codelionx.dodo.actors
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import com.github.codelionx.dodo.Settings
 import com.github.codelionx.dodo.actors.DataHolder.DataRef
 import com.github.codelionx.dodo.discovery.{CandidateGenerator, DependencyChecking}
 import com.github.codelionx.dodo.actors.ResultCollector.{OCD, OD}
@@ -34,6 +35,7 @@ class Worker(resultCollector: ActorRef) extends Actor with ActorLogging with Dep
 
   import Worker._
 
+  private val settings = Settings(context.system)
 
   override def preStart(): Unit = {
     log.info(s"Starting $name")
@@ -78,7 +80,7 @@ class Worker(resultCollector: ActorRef) extends Actor with ActorLogging with Dep
           newCandidates ++= generateODCandidates(reducedColumns, odCandidate, leftSide = false)
         }
         sender ! ODsToCheck(odCandidate, newCandidates)
-        if (foundOD) {
+        if (foundOD || !settings.ocdComparability ) {
           resultCollector ! OCD(odCandidate)
         }
       } else {


### PR DESCRIPTION
### Proposed Changes
Add the possibility to only print OCDs that do not directly lead to ODs, as `ocddiscover` does.

### Type of Changes

- [x] Feature
- [ ] Bug fix
- [ ] Refactoring

### Related
