### PR TITLE
Use column names

### DIFF
--- a/src/main/scala/com/github/codelionx/dodo/actors/ODMaster.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ODMaster.scala
@@ -79,7 +79,7 @@ class ODMaster(nWorkers: Int, resultCollector: ActorRef, systemCoordinator: Acto
           nextTuple = columnIndexTuples.next()
         }
 
-        log.debug(s"Scheduling task $nextTuple to worker ${sender.path.name}")
+        log.debug(s"Scheduling task to check equivalence of $nextTuple to worker ${sender.path.name}")
         sender ! CheckForEquivalency(nextTuple)
         pendingPruningResponses += 1
       }
@@ -114,7 +114,7 @@ class ODMaster(nWorkers: Int, resultCollector: ActorRef, systemCoordinator: Acto
         val (odToCheck, newQueue) = odsToCheck.dequeue
         odsToCheck = newQueue
 
-        log.debug(s"Scheduling task $odToCheck to worker ${sender.path.name}")
+        log.debug(s"Scheduling task to check OCD $odToCheck to worker ${sender.path.name}")
         sender ! CheckForOD(odToCheck, reducedColumns)
         waitingForODStatus += odToCheck
       }

--- a/src/main/scala/com/github/codelionx/dodo/actors/ResultCollector.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ResultCollector.scala
@@ -55,7 +55,7 @@ class ResultCollector extends Actor with ActorLogging {
         s"Order equivalent: ${
           oes
             .filter(oe => oe._2.nonEmpty)
-            .map(oe => oe._1.toString + ", " + prettyList(oe._2))
+            .map(oe => oe._1.toString + " ↔ " + prettyList(oe._2))
             .mkString
         }".stripMargin
       )

--- a/src/main/scala/com/github/codelionx/dodo/actors/ResultCollector.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ResultCollector.scala
@@ -12,13 +12,13 @@ object ResultCollector {
 
   def props(): Props = Props[ResultCollector]
 
-  case class ConstColumns(ccs: Seq[Int])
+  case class ConstColumns(ccs: Seq[String])
 
-  case class OrderEquivalencies(oe: Map[Int, Seq[Int]])
+  case class OrderEquivalencies(oe: Map[String, Seq[String]])
 
-  case class OD(od: (Seq[Int], Seq[Int]))
+  case class OD(od: (Seq[String], Seq[String]))
 
-  case class OCD(ocd: (Seq[Int], Seq[Int]))
+  case class OCD(ocd: (Seq[String], Seq[String]))
 
 }
 
@@ -48,17 +48,19 @@ class ResultCollector extends Actor with ActorLogging {
       write("Constant columns: " + prettyList(ccs))
 
     case OrderEquivalencies(oes) =>
-      write("Order Equivalent:")
-      oes.foreach(oe =>
-        if (oe._2.nonEmpty) {
-          write(oe._1.toString + ", " + prettyList(oe._2))
-        }
+      write(
+        s"Order equivalent: ${
+          oes
+            .filter(oe => oe._2.nonEmpty)
+            .map(oe => oe._1.toString + ", " + prettyList(oe._2))
+            .mkString
+        }".stripMargin
       )
 
     case OD(od) =>
       val left = prettyList(od._1)
       val right = prettyList(od._2)
-      write(s"OD: $left => $right")
+      write(s"OD: $left ↦ $right")
       // TODO: extract order equivalent ods
 
     case OCD(ocd) =>
@@ -74,7 +76,7 @@ class ResultCollector extends Actor with ActorLogging {
     log.info(message)
   }
 
-  def prettyList(l: Seq[Int]): String = {
+  def prettyList(l: Seq[String]): String = {
     val newString: StringBuilder = new StringBuilder()
     if (l.nonEmpty) {
       newString.append(l.head)

--- a/src/main/scala/com/github/codelionx/dodo/parsing/CSVParser.scala
+++ b/src/main/scala/com/github/codelionx/dodo/parsing/CSVParser.scala
@@ -38,7 +38,7 @@ class CSVParser(settings: ParsingSettings) {
     * @return the list of [[com.github.codelionx.dodo.types.TypedColumn]]s containing all data of the file
     */
   def parse(file: String): Array[TypedColumn[Any]] = {
-    val p = TypedColumnProcessor(settings.nInferringRows)
+    val p = TypedColumnProcessor(settings)
     val s = parserSettings.clone()
     s.setProcessor(p)
     val parser = new CsvParser(s)

--- a/src/main/scala/com/github/codelionx/dodo/parsing/TypedColumnProcessor.scala
+++ b/src/main/scala/com/github/codelionx/dodo/parsing/TypedColumnProcessor.scala
@@ -91,15 +91,15 @@ class TypedColumnProcessor private(settings: ParsingSettings) extends AbstractRo
     // seems very fast, so no optimization necessary
     val columnIndexToName = (i: Int) => {
       var name = ""
-      var counter = i
-      while(counter > 0) {
-        val remainder = counter % 26
+      var number = i
+      while(number > 0) {
+        val remainder = number % 26
         if(remainder == 0) {
           name += "Z"
-          counter = (counter / 26) - 1
+          number = (number / 26) - 1
         } else {
           name += ('A' + remainder - 1).toChar
-          counter /= 26
+          number /= 26
         }
       }
       name.reverse

--- a/src/main/scala/com/github/codelionx/dodo/parsing/TypedColumnProcessor.scala
+++ b/src/main/scala/com/github/codelionx/dodo/parsing/TypedColumnProcessor.scala
@@ -144,7 +144,7 @@ class TypedColumnProcessor private(settings: ParsingSettings) extends AbstractRo
      *  - but we are still in the TypeInferring state
      */
     if (state == State.TypeInferring) {
-      runEmptyingBuffer()
+      runEmptyingBuffer(context)
     }
     state = State.Finished
   }

--- a/src/main/scala/com/github/codelionx/dodo/parsing/TypedColumnProcessor.scala
+++ b/src/main/scala/com/github/codelionx/dodo/parsing/TypedColumnProcessor.scala
@@ -91,7 +91,7 @@ class TypedColumnProcessor private(settings: ParsingSettings) extends AbstractRo
     // FIXME: deal with more than 26 columns
 //    val remainder = length % 26
 //    val times = length / 26
-    ('a' to ('a' + length).toChar)
+    ('A' to ('A' + length).toChar)
       .map(_.toString)
       .toArray
   }

--- a/src/main/scala/com/github/codelionx/dodo/parsing/TypedColumnProcessor.scala
+++ b/src/main/scala/com/github/codelionx/dodo/parsing/TypedColumnProcessor.scala
@@ -1,5 +1,6 @@
 package com.github.codelionx.dodo.parsing
 
+import com.github.codelionx.dodo.Settings.ParsingSettings
 import com.github.codelionx.dodo.types.{TypedColumn, TypedColumnBuilder}
 import com.univocity.parsers.common.ParsingContext
 import com.univocity.parsers.common.processor.AbstractRowProcessor
@@ -7,7 +8,14 @@ import com.univocity.parsers.common.processor.AbstractRowProcessor
 
 object TypedColumnProcessor {
 
-  def apply(nInferringRows: Int): TypedColumnProcessor = new TypedColumnProcessor(nInferringRows)
+  /**
+    * Creates a new TypedColumnProcessor.
+    *
+    * @see [[com.github.codelionx.dodo.parsing.TypeInferrer]] for information how the data types are inferred
+    * @param settings parsing settings
+    * @return a new [[com.github.codelionx.dodo.parsing.TypedColumnProcessor]]
+    */
+  def apply(settings: ParsingSettings): TypedColumnProcessor = new TypedColumnProcessor(settings)
 
 }
 
@@ -17,9 +25,9 @@ object TypedColumnProcessor {
   * After wards all following values will be parsed to the determined data type.
   *
   * @see [[com.github.codelionx.dodo.parsing.TypeInferrer]] for information how the data types are inferred
-  * @param numberOfTypeInferringRows rows used for inferring and refining the data types for the columns
+  * @param settings parsing settings
   */
-class TypedColumnProcessor private(numberOfTypeInferringRows: Int) extends AbstractRowProcessor {
+class TypedColumnProcessor private(settings: ParsingSettings) extends AbstractRowProcessor {
 
   private object State extends Enumeration {
     type State = Value
@@ -28,7 +36,7 @@ class TypedColumnProcessor private(numberOfTypeInferringRows: Int) extends Abstr
 
   private var state: State.State = State.TypeInferring
   private var columns: Array[TypedColumnBuilder[Any]] = _
-  private val untypedRowBuffer: Array[Array[String]] = Array.ofDim(numberOfTypeInferringRows)
+  private val untypedRowBuffer: Array[Array[String]] = Array.ofDim(settings.nInferringRows)
   private var inferrer: TypeInferrer = _
   private var columnsIndex: Int = 0
   private var untypedRowBufferIndex: Int = 0
@@ -44,16 +52,23 @@ class TypedColumnProcessor private(numberOfTypeInferringRows: Int) extends Abstr
     untypedRowBufferIndex += 1
   }
 
-  private def runEmptyingBuffer(): Unit = {
+  private def runEmptyingBuffer(context: ParsingContext): Unit = {
     // type inferring finished, continue with reading the buffer again and parse it to the right types
     if (untypedRowBuffer.nonEmpty) {
       val types = inferrer.columnTypes
+      val headers: Array[String] =
+        if(settings.parseHeader)
+          context.headers()
+        else
+          generateArtificialColumnNames(types.length)
 
       // initialize column arrays
       columns = Array.ofDim(types.length)
-      types.indices.foreach(i =>
-        columns(i) = types(i).createTypedColumnBuilder
-      )
+      types.indices.foreach(i => {
+        columns(i) = types(i)
+          .createTypedColumnBuilder
+          .withName(headers(i))
+      })
 
       // fill column arrays with buffered data
       untypedRowBuffer.foreach(bufferedRow => {
@@ -72,6 +87,15 @@ class TypedColumnProcessor private(numberOfTypeInferringRows: Int) extends Abstr
     columnsIndex += 1
   }
 
+  private def generateArtificialColumnNames(length: Int): Array[String] = {
+    // FIXME: deal with more than 26 columns
+//    val remainder = length % 26
+//    val times = length / 26
+    ('a' to ('a' + length).toChar)
+      .map(_.toString)
+      .toArray
+  }
+
   /**
     * Returns the columnar data parsed from the CSV file as an array of [[com.github.codelionx.dodo.types.TypedColumn]]s.
     */
@@ -82,11 +106,11 @@ class TypedColumnProcessor private(numberOfTypeInferringRows: Int) extends Abstr
     state match {
       case State.TypeInferring =>
         runTypeInferring(row)
-        if (untypedRowBufferIndex >= numberOfTypeInferringRows)
+        if (untypedRowBufferIndex >= settings.nInferringRows)
           state = State.EmptyingBuffer
 
       case State.EmptyingBuffer =>
-        runEmptyingBuffer()
+        runEmptyingBuffer(context)
         parseRow(row)
         state = State.Parsing
 

--- a/src/main/scala/com/github/codelionx/dodo/parsing/TypedColumnProcessor.scala
+++ b/src/main/scala/com/github/codelionx/dodo/parsing/TypedColumnProcessor.scala
@@ -60,7 +60,7 @@ class TypedColumnProcessor private(settings: ParsingSettings) extends AbstractRo
         if(settings.parseHeader)
           context.headers()
         else
-          generateArtificialColumnNames(types.length)
+          generateSyntheticColumnNames(types.length)
 
       // initialize column arrays
       columns = Array.ofDim(types.length)
@@ -87,13 +87,24 @@ class TypedColumnProcessor private(settings: ParsingSettings) extends AbstractRo
     columnsIndex += 1
   }
 
-  private def generateArtificialColumnNames(length: Int): Array[String] = {
-    // FIXME: deal with more than 26 columns
-//    val remainder = length % 26
-//    val times = length / 26
-    ('A' to ('A' + length).toChar)
-      .map(_.toString)
-      .toArray
+  private def generateSyntheticColumnNames(length: Int): Array[String] = {
+    // seems very fast, so no optimization necessary
+    val columnIndexToName = (i: Int) => {
+      var name = ""
+      var counter = i
+      while(counter > 0) {
+        val remainder = counter % 26
+        if(remainder == 0) {
+          name += "Z"
+          counter = (counter / 26) - 1
+        } else {
+          name += ('A' + remainder - 1).toChar
+          counter /= 26
+        }
+      }
+      name.reverse
+    }
+    (1 to length).map(columnIndexToName).toArray
   }
 
   /**

--- a/src/main/scala/com/github/codelionx/dodo/types/TypedColumn.scala
+++ b/src/main/scala/com/github/codelionx/dodo/types/TypedColumn.scala
@@ -25,6 +25,11 @@ abstract class TypedColumnBase[T <: Any](implicit ev: ClassTag[T]) {
     * Returns the backing array of this `TypedColumn`.
     */
   def array: Array[T]
+
+  /**
+    * Column name
+    */
+  def name: String
 }
 
 /**
@@ -65,7 +70,7 @@ trait TypedColumn[T <: Any]
     */
   private final class BuilderAdapter extends mutable.ReusableBuilder[T, TypedColumn[T]] {
 
-    private val internalBuilder = TypedColumnBuilder[T](dataType)(tag)
+    private val internalBuilder = TypedColumnBuilder[T](dataType, name)(tag)
 
     override def clear(): Unit = internalBuilder.clear()
 


### PR DESCRIPTION
### Proposed Changes

- [x] parse csv header or generate artificial column names
- [x] store these names in the `TypedColumn`
- [x] deal with more than 26 columns in name generation (`AA`, `AB`, ...)
- [x] let worker substitute the column names for the column indices in the OCDs and ODs before submitting them to the result collector

### Type of Changes

- [x] Feature
- [ ] Bug fix
- [ ] Refactoring

Closes #11
