### PR TITLE
Output correct column index for constant columns

### DIFF
--- a/src/main/scala/com/github/codelionx/dodo/actors/ODMaster.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ODMaster.scala
@@ -38,7 +38,6 @@ class ODMaster(nWorkers: Int, resultCollector: ActorRef, systemCoordinator: Acto
   override def preStart(): Unit = {
     log.info(s"Starting $name")
     Reaper.watchWithDefault(self)
-    // TODO make reaper watch workers
   }
 
   override def postStop(): Unit =
@@ -132,9 +131,9 @@ class ODMaster(nWorkers: Int, resultCollector: ActorRef, systemCoordinator: Acto
 
   def pruneConstColumns(table: Array[TypedColumn[Any]]): Seq[Int] = {
     val constColumns = for {
-      column <- table
+      (column, index) <- table.zipWithIndex
       if checkConstant(column)
-    } yield table.indexOf(column)
+    } yield index
 
     reducedColumns --= constColumns
     constColumns

--- a/src/main/scala/com/github/codelionx/dodo/types/TypedColumn.scala
+++ b/src/main/scala/com/github/codelionx/dodo/types/TypedColumn.scala
@@ -49,7 +49,7 @@ trait TypedColumn[T <: Any]
 
   // overrides of [[java.lang.Object]]
 
-  override def hashCode(): Int = Objects.hash(dataType, array.toSeq)
+  override def hashCode(): Int = Objects.hash(dataType, name, array.toSeq)
 
   override def canEqual(o: Any): Boolean = o.isInstanceOf[TypedColumn[T]]
 


### PR DESCRIPTION
### Proposed Changes

Change `indexOf`-lookup for getting the column index of constant columns to `zipWithIndex`-call.
This fixes a bug on datasets with some columns with exactly the same content (e.g. two columns with all `null`-values) returning the index of the first same column multiple times. This also slightly improves performance.

To be sure, the comparison operators (`hashCode` and `equals`) of `TypedColumn`s now consider the column name as well.

### Type of Changes

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring
