### PR TITLE
Cluster listener

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
 )
 
 // set main class for assembly
-//mainClass in assembly := Some("com.github.codelionx.dodo.App")
+mainClass in assembly := Some("com.github.codelionx.dodo.Main")
 
 // skip tests during assembly
-//test in assembly := {}
+test in assembly := {}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -9,15 +9,15 @@ akka {
     allow-java-serialization = off
 
     serializers {
-    #  proto = "akka.remote.serialization.ProtobufSerializer"
-    #  kryo = "com.romix.akka.serialization.kryo.KryoSerializer"
+      #  proto = "akka.remote.serialization.ProtobufSerializer"
+      #  kryo = "com.romix.akka.serialization.kryo.KryoSerializer"
       kryo = "com.twitter.chill.akka.AkkaSerializer"
     }
     serialization-bindings {
       "java.io.Serializable" = kryo
       "scala.Serializable" = kryo
-    #  "com.github.leananeuber.hasher.protocols.SerializableMessage" = kryo
-    #  "com.google.protobuf.Message" = proto
+      #  "com.github.leananeuber.hasher.protocols.SerializableMessage" = kryo
+      #  "com.google.protobuf.Message" = proto
     }
 
     #kryo {
@@ -29,7 +29,7 @@ akka {
   remote {
     artery {
       enabled = on
-      canonical.hostname = "<getHostAddress>"
+      canonical.hostname = "127.0.0.1"
       canonical.port = 7877
 
       ## allow sending large messages to and from workers through a separate channel
@@ -43,10 +43,17 @@ akka {
   cluster {
     min-nr-of-members = 1
 
-    role {
-      leader.min-nr-of-members = 1
-      follower.min-nr-of-members = 0
-    }
+    # role {
+    #   leader.min-nr-of-members = 1
+    #   follower.min-nr-of-members = 0
+    # }
+    # roles = [
+    #   "leader"
+    # ]
+
+    seed-nodes = [
+      "akka://dodo-system@127.0.0.1:7877"
+    ]
 
     # not production-safe, but could help during dev.
     #auto-down-unreachable-after = 10s
@@ -62,6 +69,6 @@ akka {
 
 # Sigar native library extract location during tests.
 # Note: use per-jvm-instance folder when running multiple jvm on one host.
-akka.cluster.metrics.native-library-extract-folder=${user.dir}/target/native
+akka.cluster.metrics.native-library-extract-folder = ${user.dir}/target/native
 
 #extensions = ["com.romix.akka.serialization.kryo.KryoSerializationExtension$"]

--- a/src/main/scala/com/github/codelionx/dodo/ActorSystem.scala
+++ b/src/main/scala/com/github/codelionx/dodo/ActorSystem.scala
@@ -4,12 +4,16 @@ import akka.cluster.Cluster
 import com.typesafe.config.{Config, ConfigFactory}
 
 import scala.concurrent.Await
-
-import scala.language.postfixOps
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
 
 object ActorSystem {
+
+  private val configFilename = "application"
+
+  def defaultConfiguration: Config = ConfigFactory.load(configFilename)
 
   def configuration(actorSystemName: String, actorSystemRole: String, host: String, port: Int, masterHost: String, masterPort: Int): Config = {
     ConfigFactory.parseString(
@@ -20,7 +24,7 @@ object ActorSystem {
          |  "akka://$actorSystemName@$masterHost:$masterPort"
          |]
        """.stripMargin)
-      .withFallback(ConfigFactory.load("application"))
+      .withFallback(ConfigFactory.load(configFilename))
   }
 
   def actorSystem(actorSystemName: String, config: Config): akka.actor.ActorSystem = {

--- a/src/main/scala/com/github/codelionx/dodo/ActorSystem.scala
+++ b/src/main/scala/com/github/codelionx/dodo/ActorSystem.scala
@@ -11,9 +11,7 @@ import scala.language.postfixOps
 
 object ActorSystem {
 
-  private val configFilename = "application"
-
-  def defaultConfiguration: Config = ConfigFactory.load(configFilename)
+  def defaultConfiguration: Config = ConfigFactory.load()
 
   def configuration(actorSystemName: String, actorSystemRole: String, host: String, port: Int, masterHost: String, masterPort: Int): Config = {
     ConfigFactory.parseString(
@@ -24,7 +22,7 @@ object ActorSystem {
          |  "akka://$actorSystemName@$masterHost:$masterPort"
          |]
        """.stripMargin)
-      .withFallback(ConfigFactory.load(configFilename))
+      .withFallback(ConfigFactory.load())
   }
 
   def actorSystem(actorSystemName: String, config: Config): akka.actor.ActorSystem = {

--- a/src/main/scala/com/github/codelionx/dodo/Main.scala
+++ b/src/main/scala/com/github/codelionx/dodo/Main.scala
@@ -1,9 +1,8 @@
 package com.github.codelionx.dodo
 
 import akka.cluster.Cluster
-import com.github.codelionx.dodo.Settings.DefaultValues
 import com.github.codelionx.dodo.actors.SystemCoordinator.Initialize
-import com.github.codelionx.dodo.actors.{ClusterListener, Reaper, SystemCoordinator}
+import com.github.codelionx.dodo.actors.{Reaper, SystemCoordinator}
 
 import scala.language.postfixOps
 
@@ -14,23 +13,15 @@ object Main {
 
   def main(args: Array[String]): Unit = {
 
-    val system = ActorSystem.actorSystem(actorSystemName, ActorSystem.configuration(
-      actorSystemName = actorSystemName,
-      actorSystemRole = DefaultValues.NodeRole.Leader,
-      host = DefaultValues.HOST,
-      port = DefaultValues.PORT,
-      masterHost = DefaultValues.HOST,
-      masterPort = DefaultValues.PORT
-    ))
+    val system = ActorSystem.actorSystem(actorSystemName, ActorSystem.defaultConfiguration)
 
     val cluster = Cluster(system)
 
     cluster.registerOnMemberUp {
 
       system.actorOf(Reaper.props, Reaper.name)
-      val clusterListener = system.actorOf(ClusterListener.props, ClusterListener.name)
-      val systemCoordinator = system.actorOf(SystemCoordinator.props(), SystemCoordinator.name)
 
+      val systemCoordinator = system.actorOf(SystemCoordinator.props(), SystemCoordinator.name)
       systemCoordinator ! Initialize
     }
 

--- a/src/main/scala/com/github/codelionx/dodo/Main.scala
+++ b/src/main/scala/com/github/codelionx/dodo/Main.scala
@@ -2,10 +2,9 @@ package com.github.codelionx.dodo
 
 import akka.cluster.Cluster
 import com.github.codelionx.dodo.Settings.DefaultValues
-import com.github.codelionx.dodo.actors.SystemCoordinator.{Shutdown, Initialize}
-import com.github.codelionx.dodo.actors.{Reaper, SystemCoordinator}
+import com.github.codelionx.dodo.actors.SystemCoordinator.Initialize
+import com.github.codelionx.dodo.actors.{ClusterListener, Reaper, SystemCoordinator}
 
-import scala.concurrent.duration._
 import scala.language.postfixOps
 
 
@@ -29,6 +28,7 @@ object Main {
     cluster.registerOnMemberUp {
 
       system.actorOf(Reaper.props, Reaper.name)
+      system.actorOf(ClusterListener.props)
       val systemCoordinator = system.actorOf(SystemCoordinator.props(), SystemCoordinator.name)
 
       systemCoordinator ! Initialize

--- a/src/main/scala/com/github/codelionx/dodo/Main.scala
+++ b/src/main/scala/com/github/codelionx/dodo/Main.scala
@@ -28,7 +28,7 @@ object Main {
     cluster.registerOnMemberUp {
 
       system.actorOf(Reaper.props, Reaper.name)
-      system.actorOf(ClusterListener.props)
+      val clusterListener = system.actorOf(ClusterListener.props, ClusterListener.name)
       val systemCoordinator = system.actorOf(SystemCoordinator.props(), SystemCoordinator.name)
 
       systemCoordinator ! Initialize

--- a/src/main/scala/com/github/codelionx/dodo/actors/ClusterListener.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ClusterListener.scala
@@ -1,9 +1,11 @@
 package com.github.codelionx.dodo.actors
 
-import akka.actor.{Actor, ActorLogging, Props}
+import akka.actor.{Actor, ActorLogging, Props, RootActorPath}
 import akka.cluster.ClusterEvent._
-import akka.cluster.{Cluster, Member, UniqueAddress}
+import akka.cluster.{Cluster, Member}
 import com.github.codelionx.dodo.actors.ClusterListener.{GetLeftNeighbour, LeftNeighbour}
+
+import scala.util.Try
 
 
 object ClusterListener {
@@ -14,24 +16,25 @@ object ClusterListener {
 
   case object GetLeftNeighbour
 
-  case class LeftNeighbour(address: UniqueAddress)
+  case class LeftNeighbour(address: RootActorPath)
 
 }
 
 
 class ClusterListener extends Actor with ActorLogging {
 
-  implicit val memberOrder: Ordering[Member] = Member.ageOrdering
+  implicit private val memberOrder: Ordering[Member] = Member.ageOrdering
 
   private val cluster = Cluster(context.system)
+  private val selfMember = cluster.selfMember
 
-  cluster.selfMember
-
-  override def preStart(): Unit =
+  override def preStart(): Unit = {
+    Reaper.watchWithDefault(self)
     cluster.subscribe(self, initialStateMode = InitialStateAsEvents,
       classOf[MemberUp], classOf[MemberRemoved],
       classOf[UnreachableMember], classOf[ReachableMember]
     )
+  }
 
   override def postStop(): Unit =
     cluster.unsubscribe(self)
@@ -52,20 +55,27 @@ class ClusterListener extends Actor with ActorLogging {
       log.info(s"$node detected reachable again")
 
     case GetLeftNeighbour =>
-      val selfMember = cluster.selfMember
-      val selfPosition = members.indexOf(selfMember)
+      getLeftNeighbour(members)
+        .map(member =>
+          sender ! LeftNeighbour(RootActorPath(member.address))
+        )
+        .recover(sendError)
+  }
 
-      val leftMember = selfPosition match {
-        case -1 =>
-          log.error("our node is not up yet??")
-          throw new RuntimeException("Could not find self node in the member list!")
-        case 0 =>
-          members.last
-        case i =>
-          members(i - 1)
-      }
+  private def sendError: PartialFunction[Throwable, Unit] = {
+    case error => sender ! akka.actor.Status.Failure(error)
+  }
 
-      sender ! LeftNeighbour(leftMember.uniqueAddress)
-
+  private def getLeftNeighbour(members: Seq[Member]): Try[Member] = Try {
+    members.indexOf(selfMember) match {
+      case -1 =>
+        log.error("our node is not up yet??")
+        log.info(s"current member list: ${members.mkString(", ")}")
+        throw new RuntimeException("Could not find self node in the member list!")
+      case 0 =>
+        members.last
+      case i =>
+        members(i - 1)
+    }
   }
 }

--- a/src/main/scala/com/github/codelionx/dodo/actors/ClusterListener.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ClusterListener.scala
@@ -1,0 +1,44 @@
+package com.github.codelionx.dodo.actors
+
+import akka.actor.{Actor, ActorLogging, Props}
+import akka.cluster.ClusterEvent._
+import akka.cluster.{Cluster, Member}
+
+
+object ClusterListener {
+
+  def props: Props = Props[ClusterListener]
+}
+
+
+class ClusterListener extends Actor with ActorLogging {
+
+  implicit val memberOrder: Ordering[Member] = Member.ageOrdering
+
+  private val cluster = Cluster(context.system)
+
+  override def preStart(): Unit =
+    cluster.subscribe(self, initialStateMode = InitialStateAsEvents,
+      classOf[MemberUp], classOf[MemberRemoved],
+      classOf[UnreachableMember], classOf[ReachableMember]
+    )
+
+  override def postStop(): Unit =
+    cluster.unsubscribe(self)
+
+  override def receive: Receive = internalReceive(Nil)
+
+  def internalReceive(members: List[Member]): Receive = {
+    case MemberUp(node) =>
+      context.become(internalReceive((node :: members).sorted))
+
+    case MemberRemoved(node, _) =>
+      context.become(internalReceive(members.filterNot(_ == node)))
+
+    case UnreachableMember(node) =>
+      log.info(s"$node detected unreachable")
+
+    case ReachableMember(node) =>
+      log.info(s"$node detected reachable again")
+  }
+}

--- a/src/main/scala/com/github/codelionx/dodo/actors/ClusterListener.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ClusterListener.scala
@@ -2,12 +2,20 @@ package com.github.codelionx.dodo.actors
 
 import akka.actor.{Actor, ActorLogging, Props}
 import akka.cluster.ClusterEvent._
-import akka.cluster.{Cluster, Member}
+import akka.cluster.{Cluster, Member, UniqueAddress}
+import com.github.codelionx.dodo.actors.ClusterListener.{GetLeftNeighbour, LeftNeighbour}
 
 
 object ClusterListener {
 
+  val name = "clistener"
+
   def props: Props = Props[ClusterListener]
+
+  case object GetLeftNeighbour
+
+  case class LeftNeighbour(address: UniqueAddress)
+
 }
 
 
@@ -16,6 +24,8 @@ class ClusterListener extends Actor with ActorLogging {
   implicit val memberOrder: Ordering[Member] = Member.ageOrdering
 
   private val cluster = Cluster(context.system)
+
+  cluster.selfMember
 
   override def preStart(): Unit =
     cluster.subscribe(self, initialStateMode = InitialStateAsEvents,
@@ -28,9 +38,9 @@ class ClusterListener extends Actor with ActorLogging {
 
   override def receive: Receive = internalReceive(Nil)
 
-  def internalReceive(members: List[Member]): Receive = {
+  def internalReceive(members: Seq[Member]): Receive = {
     case MemberUp(node) =>
-      context.become(internalReceive((node :: members).sorted))
+      context.become(internalReceive((members :+ node).sorted))
 
     case MemberRemoved(node, _) =>
       context.become(internalReceive(members.filterNot(_ == node)))
@@ -40,5 +50,22 @@ class ClusterListener extends Actor with ActorLogging {
 
     case ReachableMember(node) =>
       log.info(s"$node detected reachable again")
+
+    case GetLeftNeighbour =>
+      val selfMember = cluster.selfMember
+      val selfPosition = members.indexOf(selfMember)
+
+      val leftMember = selfPosition match {
+        case -1 =>
+          log.error("our node is not up yet??")
+          throw new RuntimeException("Could not find self node in the member list!")
+        case 0 =>
+          members.last
+        case i =>
+          members(i - 1)
+      }
+
+      sender ! LeftNeighbour(leftMember.uniqueAddress)
+
   }
 }

--- a/src/main/scala/com/github/codelionx/dodo/actors/ClusterListener.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ClusterListener.scala
@@ -13,11 +13,11 @@ object ClusterListener {
 
   def props: Props = Props[ClusterListener]
 
-  case object GetLeftNeighbour
-  case class LeftNeighbour(address: RootActorPath)
+  case object GetLeftNeighbor
+  case class LeftNeighbor(address: RootActorPath)
 
-  case object GetRightNeighbour
-  case class RightNeighbour(address: RootActorPath)
+  case object GetRightNeighbor
+  case class RightNeighbor(address: RootActorPath)
 
   class ClusterStateException(message: String, cause: Throwable = null) extends RuntimeException(message, cause) {
     def this(cause: Throwable) = this(cause.getMessage, cause)
@@ -62,22 +62,22 @@ class ClusterListener extends Actor with ActorLogging {
     case ReachableMember(node) =>
       log.info(s"$node detected reachable again")
 
-    case GetLeftNeighbour if members.length >= 2 =>
-      getLeftNeighbour(members)
-        .map(member => sender ! LeftNeighbour(RootActorPath(member.address)))
+    case GetLeftNeighbor if members.length >= 2 =>
+      getLeftNeighbor(members)
+        .map(member => sender ! LeftNeighbor(RootActorPath(member.address)))
         .recover(sendError)
 
-    case GetRightNeighbour if members.length >= 2 =>
-      getRightNeighbour(members)
-        .map(member => sender ! RightNeighbour(RootActorPath(member.address)))
+    case GetRightNeighbor if members.length >= 2 =>
+      getRightNeighbor(members)
+        .map(member => sender ! RightNeighbor(RootActorPath(member.address)))
         .recover(sendError)
 
-    case GetLeftNeighbour | GetRightNeighbour if members.length < 2 =>
-      log.warning(s"Cluster size too small for neighbour operations: ${members.length}")
+    case GetLeftNeighbor | GetRightNeighbor if members.length < 2 =>
+      log.warning(s"Cluster size too small for neighbor operations: ${members.length}")
       sendError.apply(new ClusterStateException(s"Cluster size is too small: only ${members.length} of 2 members"))
   }
 
-  private def getLeftNeighbour(members: Seq[Member]): Try[Member] = Try {
+  private def getLeftNeighbor(members: Seq[Member]): Try[Member] = Try {
     members.indexOf(selfMember) match {
       case -1 => throwSelfNotFound
       case  0 => members.last
@@ -85,7 +85,7 @@ class ClusterListener extends Actor with ActorLogging {
     }
   }
 
-  private def getRightNeighbour(members: Seq[Member]): Try[Member] = Try {
+  private def getRightNeighbor(members: Seq[Member]): Try[Member] = Try {
     val end = members.length - 1
     members.indexOf(selfMember) match {
       case  -1   => throwSelfNotFound

--- a/src/test/scala/com/github/codelionx/dodo/ODDetectionSpec.scala
+++ b/src/test/scala/com/github/codelionx/dodo/ODDetectionSpec.scala
@@ -5,12 +5,24 @@ import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import com.github.codelionx.dodo.actors.ResultCollector.{ConstColumns, OrderEquivalencies, Results}
 import com.github.codelionx.dodo.actors.SystemCoordinator
 import com.github.codelionx.dodo.actors.SystemCoordinator.Initialize
+import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class ODDetectionSpec extends TestKit(AkkaActorSystem("ODDetectionSpec"))
+
+object ODDetectionSpec {
+  val config: Config = ConfigFactory.parseString(
+    """akka.remote.artery.canonical.hostname = "127.0.0.1"
+       |akka.remote.artery.canonical.port = "7880"
+       |akka.cluster.seed-nodes = [
+       |  "akka://ODDetectionSpec@127.0.0.1:7880"
+       |]
+     """.stripMargin)
+    .withFallback(ConfigFactory.load())
+}
+class ODDetectionSpec extends TestKit(AkkaActorSystem("ODDetectionSpec", ODDetectionSpec.config))
   with ImplicitSender
   with WordSpecLike
   with Matchers

--- a/src/test/scala/com/github/codelionx/dodo/SerializationSpec.scala
+++ b/src/test/scala/com/github/codelionx/dodo/SerializationSpec.scala
@@ -17,8 +17,11 @@ object SerializationSpec {
   val config: Config = ConfigFactory.parseString(
     s"""akka.remote.artery.canonical.hostname = "127.0.0.1"
        |akka.remote.artery.canonical.port = "7990"
+       |akka.cluster.seed-nodes = [
+       |  "akka://SerializationSpec@127.0.0.1:7990"
+       |]
        """.stripMargin)
-    .withFallback(ConfigFactory.load("application"))
+    .withFallback(ConfigFactory.load())
 }
 
 


### PR DESCRIPTION
### Proposed Changes

Adds a cluster listener actor:

- subscribes to cluster events and maintains a list (sequence) of the active cluster members (ordered by their age)
- provides an interface to request the left and right neighbor of the current node

> **Attention!**
>
> The neighbor references should be requested once for messages to be sent in a very short period of time. Joining and leaving nodes will invalidate the references sooner or later. The cluster listener takes care of this in the neighbor calculation, but the cached references do not.

### Type of Changes

- [x] Feature
- [ ] Bug fix
- [ ] Refactoring
