### PR TITLE
Feature/batching o ds to check

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -4,6 +4,9 @@ com.github.codelionx.dodo {
   // number of workers to spawn
   workers = 1
 
+  // max number of ODs to check send to one worker at a time
+  max-batch-size = 100
+
   // print only some found OCDs for better comparability to ocddiscover
   ocd-comparability = true
 

--- a/src/main/scala/com/github/codelionx/dodo/Settings.scala
+++ b/src/main/scala/com/github/codelionx/dodo/Settings.scala
@@ -47,6 +47,8 @@ class Settings(config: Config) extends Extension {
 
   val workers: Int = config.getInt(s"$namespace.workers")
 
+  val maxBatchSize: Int = config.getInt(s"$namespace.max-batch-size")
+
   val ocdComparability: Boolean = config.getBoolean(s"$namespace.ocd-comparability")
 
   val parsing: ParsingSettings = new ParsingSettings(config, namespace)

--- a/src/main/scala/com/github/codelionx/dodo/actors/ODMaster.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ODMaster.scala
@@ -110,7 +110,7 @@ class ODMaster(nWorkers: Int, resultCollector: ActorRef, systemCoordinator: Acto
   def findingODs(table: Array[TypedColumn[Any]]): Receive = {
     case GetTask =>
       if (odsToCheck.nonEmpty) {
-        val batchLength = odsToCheck.length / nWorkers
+        val batchLength = math.max(odsToCheck.length / nWorkers, odsToCheck.length)
         val (workerODs, newQueue) = odsToCheck.splitAt(batchLength)
         odsToCheck = newQueue
 

--- a/src/main/scala/com/github/codelionx/dodo/actors/ResultCollector.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ResultCollector.scala
@@ -16,9 +16,7 @@ object ResultCollector {
 
   case class OrderEquivalencies(oe: Map[String, Seq[String]])
 
-  case class ODs(od: Seq[(Seq[String], Seq[String])])
-
-  case class OCDs(ocd: Seq[(Seq[String], Seq[String])])
+  case class Results(ods: Seq[(Seq[String], Seq[String])], ocds: Seq[(Seq[String], Seq[String])])
 
 }
 
@@ -60,15 +58,13 @@ class ResultCollector extends Actor with ActorLogging {
         }".stripMargin
       )
 
-    case ODs(ods) =>
+    case Results(ods, ocds) =>
       for (od <- ods) {
         val left = prettyList(od._1)
         val right = prettyList(od._2)
         write(s"OD: $left ↦ $right")
         odsFound += 1
       }
-
-    case OCDs(ocds) =>
       for (ocd <- ocds) {
         val left = prettyList(ocd._1)
         val right = prettyList(ocd._2)

--- a/src/main/scala/com/github/codelionx/dodo/actors/ResultCollector.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ResultCollector.scala
@@ -16,9 +16,9 @@ object ResultCollector {
 
   case class OrderEquivalencies(oe: Map[String, Seq[String]])
 
-  case class OD(od: (Seq[String], Seq[String]))
+  case class ODs(od: Seq[(Seq[String], Seq[String])])
 
-  case class OCD(ocd: (Seq[String], Seq[String]))
+  case class OCDs(ocd: Seq[(Seq[String], Seq[String])])
 
 }
 
@@ -60,20 +60,23 @@ class ResultCollector extends Actor with ActorLogging {
         }".stripMargin
       )
 
-    case OD(od) =>
-      val left = prettyList(od._1)
-      val right = prettyList(od._2)
-      write(s"OD: $left ↦ $right")
-      odsFound += 1
-      // TODO: extract order equivalent ods
-
-    case OCD(ocd) =>
-      val left = prettyList(ocd._1)
-      val right = prettyList(ocd._2)
-      if (settings.ocdComparability) {
+    case ODs(ods) =>
+      for (od <- ods) {
+        val left = prettyList(od._1)
+        val right = prettyList(od._2)
+        write(s"OD: $left ↦ $right")
         odsFound += 1
       }
-      write(s"OCD: $left ~ $right")
+
+    case OCDs(ocds) =>
+      for (ocd <- ocds) {
+        val left = prettyList(ocd._1)
+        val right = prettyList(ocd._2)
+        if (settings.ocdComparability) {
+          odsFound += 1
+        }
+        write(s"OCD: $left ~ $right")
+      }
 
     case _ => log.info("Unknown message received")
   }

--- a/src/main/scala/com/github/codelionx/dodo/actors/Worker.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/Worker.scala
@@ -4,7 +4,7 @@ import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import com.github.codelionx.dodo.Settings
 import com.github.codelionx.dodo.actors.DataHolder.DataRef
 import com.github.codelionx.dodo.discovery.{CandidateGenerator, DependencyChecking}
-import com.github.codelionx.dodo.actors.ResultCollector.{OCDs, ODs}
+import com.github.codelionx.dodo.actors.ResultCollector.Results
 import com.github.codelionx.dodo.types.TypedColumn
 
 import scala.collection.immutable.Queue
@@ -85,8 +85,9 @@ class Worker(resultCollector: ActorRef) extends Actor with ActorLogging with Dep
           }
         }
       }
-      resultCollector ! ODs(foundODs)
-      resultCollector ! OCDs(foundOCDs)
+      if (foundODs.nonEmpty || foundOCDs.nonEmpty) {
+        resultCollector ! Results(foundODs, foundOCDs)
+      }
       sender ! ODsToCheck(odCandidates, newCandidates)
       sender ! GetTask
 

--- a/src/test/scala/com/github/codelionx/dodo/ODDetectionSpec.scala
+++ b/src/test/scala/com/github/codelionx/dodo/ODDetectionSpec.scala
@@ -2,7 +2,7 @@ package com.github.codelionx.dodo
 
 import akka.actor.{ActorRef, Props, ActorSystem => AkkaActorSystem}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
-import com.github.codelionx.dodo.actors.ResultCollector.{ConstColumns, OCDs, ODs, OrderEquivalencies}
+import com.github.codelionx.dodo.actors.ResultCollector.{ConstColumns, OrderEquivalencies, Results}
 import com.github.codelionx.dodo.actors.SystemCoordinator
 import com.github.codelionx.dodo.actors.SystemCoordinator.Initialize
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
@@ -40,8 +40,9 @@ class ODDetectionSpec extends TestKit(AkkaActorSystem("ODDetectionSpec"))
       var ocds: Set[(Seq[String], Seq[String])] = Set.empty
       var ods: Set[(Seq[String], Seq[String])] = Set.empty
       probe.receiveWhile(max = 500 millis) {
-        case OCDs(ocd) => ocds ++= ocd.toSet
-        case ODs(od) => ods ++= od.toSet
+        case Results(od, ocd) =>
+          ods ++= od.toSet
+          ocds ++= ocd.toSet
       }
       val expectedODs = Set(
         (Seq("A"), Seq("B")),

--- a/src/test/scala/com/github/codelionx/dodo/ODDetectionSpec.scala
+++ b/src/test/scala/com/github/codelionx/dodo/ODDetectionSpec.scala
@@ -2,7 +2,7 @@ package com.github.codelionx.dodo
 
 import akka.actor.{ActorRef, Props, ActorSystem => AkkaActorSystem}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
-import com.github.codelionx.dodo.actors.ResultCollector.{ConstColumns, OCD, OD, OrderEquivalencies}
+import com.github.codelionx.dodo.actors.ResultCollector.{ConstColumns, OCDs, ODs, OrderEquivalencies}
 import com.github.codelionx.dodo.actors.SystemCoordinator
 import com.github.codelionx.dodo.actors.SystemCoordinator.Initialize
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
@@ -40,8 +40,8 @@ class ODDetectionSpec extends TestKit(AkkaActorSystem("ODDetectionSpec"))
       var ocds: Set[(Seq[String], Seq[String])] = Set.empty
       var ods: Set[(Seq[String], Seq[String])] = Set.empty
       probe.receiveWhile(max = 500 millis) {
-        case OCD(ocd) => ocds += ocd
-        case OD(od) => ods += od
+        case OCDs(ocd) => ocds ++= ocd.toSet
+        case ODs(od) => ods ++= od.toSet
       }
       val expectedODs = Set(
         (Seq("A"), Seq("B")),


### PR DESCRIPTION
### Proposed Changes
Send batches of ODs to check to the Workers instead of one OD at a time to decrease the number of messages being exchanged. 

#### Things to consider going forward
- Currently the size of the batches is calculated by dividing the length of the queue by the number of workers. Since the queue changes its length constantly this will lead to batches of many different sizes. Further testing is necessary to determine if a better distribution of workload can be reached by using a different formula for batch sizes
- We should consider giving each queue that's sent to a worker an identifier, so the answer can use this instead of sending the whole queue back. This will also be helpful later on when the result collector starts communicating with the master about the found results.

### Type of Changes

- [x] Feature
- [ ] Bug fix
- [ ] Refactoring

### Related
