### PR TITLE
Improve logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,3 @@ data
 
 # intellij (openjdk) pid files
 .attach_pid*
-
-# log file
-log.txt

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -63,7 +63,7 @@ akka {
 # logging
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
-  loglevel = "DEBUG"
+  loglevel = "INFO"
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 }
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
 
     <appender name="FILE_DODO" class="ch.qos.logback.core.FileAppender">
         <file>dodo.log</file>
-        <append>true</append>
+        <append>false</append>
         <encoder>
             <pattern>[%d{HH:mm:ss.SSS} %-5level] %60.60X{akkaSource:-local}| %msg%n</pattern>
         </encoder>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,16 +7,28 @@
         </encoder>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>log.txt </file>
+    <appender name="FILE_DODO" class="ch.qos.logback.core.FileAppender">
+        <file>dodo.log</file>
         <append>true</append>
         <encoder>
             <pattern>[%d{HH:mm:ss.SSS} %-5level] %60.60X{akkaSource:-local}| %msg%n</pattern>
         </encoder>
     </appender>
 
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>all.log</file>
+        <append>true</append>
+        <encoder>
+            <pattern>[%d{HH:mm:ss.SSS} %-5level] %60.60X{akkaSource:-local}| %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.github.codelionx.dodo" level="DEBUG">
+        <appender-ref ref="FILE_DODO" />
+    </logger>
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,11 +1,20 @@
 // default values for the dODo algorithms
 com.github.codelionx.dodo {
 
+  // filepath pointing to a dataset that is read and analyzed for ODs
+  input-file = ""
+
+  // filepath where the result is stored
+  output-file = ""
+
+  // should the results also be printed to console?
+  output-to-console = false
+
   // number of workers to spawn
   workers = 1
 
   // max number of ODs to check send to one worker at a time
-  max-batch-size = 100
+  max-batch-size = 1000
 
   // print only some found OCDs for better comparability to ocddiscover
   ocd-comparability = true

--- a/src/main/scala/com/github/codelionx/dodo/Settings.scala
+++ b/src/main/scala/com/github/codelionx/dodo/Settings.scala
@@ -45,6 +45,8 @@ class Settings(config: Config) extends Extension {
 
   val outputFilePath: String = config.getString(s"$namespace.output-file")
 
+  val outputToConsole: Boolean = config.getBoolean(s"$namespace.output-to-console")
+
   val workers: Int = config.getInt(s"$namespace.workers")
 
   val maxBatchSize: Int = config.getInt(s"$namespace.max-batch-size")

--- a/src/main/scala/com/github/codelionx/dodo/actors/ClusterListener.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ClusterListener.scala
@@ -51,16 +51,18 @@ class ClusterListener extends Actor with ActorLogging {
 
   def internalReceive(members: Seq[Member]): Receive = {
     case MemberUp(node) =>
+      log.debug("New node ({}) joined the cluster", node)
       context.become(internalReceive((members :+ node).sorted))
 
     case MemberRemoved(node, _) =>
+      log.debug("Node ({}) left the cluster", node)
       context.become(internalReceive(members.filterNot(_ == node)))
 
     case UnreachableMember(node) =>
-      log.info(s"$node detected unreachable")
+      log.info("Node ({}) detected unreachable", node)
 
     case ReachableMember(node) =>
-      log.info(s"$node detected reachable again")
+      log.info("Node ({}) detected reachable again", node)
 
     case GetLeftNeighbor if members.length >= 2 =>
       getLeftNeighbor(members)
@@ -73,7 +75,7 @@ class ClusterListener extends Actor with ActorLogging {
         .recover(sendError)
 
     case GetLeftNeighbor | GetRightNeighbor if members.length < 2 =>
-      log.warning(s"Cluster size too small for neighbor operations: ${members.length}")
+      log.warning("Cluster size too small for neighbor operations: {}", members.length)
       sendError.apply(new ClusterStateException(s"Cluster size is too small: only ${members.length} of 2 members"))
   }
 

--- a/src/main/scala/com/github/codelionx/dodo/actors/DataHolder.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/DataHolder.scala
@@ -64,7 +64,7 @@ class DataHolder(publicHostname: String) extends Actor with ActorLogging {
     implicit val system: ActorSystem = context.system
 
     val handler: IncomingConnection => Unit = connection => {
-      log.info(s"Received connection from ${connection.remoteAddress}")
+      log.info("Received connection from {}", connection.remoteAddress)
       // handle incoming requests in own actor
       context.actorOf(DataStreamServant.props(data, connection), s"streamServant-${r.nextInt()}")
     }
@@ -81,14 +81,14 @@ class DataHolder(publicHostname: String) extends Actor with ActorLogging {
             // no specific error in reasonable amount of time: assuming a successful binding
             port
           case error =>
-            log.warning(s"Binding to port $port failed (${error.getMessage}). Trying again on ${port + 1}")
+            log.warning("Binding to port {} failed ({}). Trying again on {}", port, error.getMessage, port + 1)
             tryBindTo(port + 1)
         }
       }
     }
 
     val port = tryBindTo(DefaultValues.PORT + 1000)
-    log.info(s"Accepting incoming connections to $port")
+    log.info("Accepting incoming connections to {}", port)
     port
   }
 
@@ -119,7 +119,7 @@ class DataHolder(publicHostname: String) extends Actor with ActorLogging {
       val data = CSVParser(settings.parsing).parse(localFilename)
       val port = openSidechannel(data)
 
-      log.info(s"Loaded data from $localFilename. $name is ready")
+      log.info("Loaded data from {}. {} is ready", localFilename, name)
       sender ! DataLoaded
       context.become(dataReady(data, port))
 
@@ -135,7 +135,7 @@ class DataHolder(publicHostname: String) extends Actor with ActorLogging {
       context.become(handleStreamResult(originalSender, socketAddress))
 
     case DataNotReady =>
-      log.error(s"Other data holder (${sender.path}) is no ready yet.")
+      log.error("Other data holder ({}) is no ready yet.", sender.path)
       throw new RuntimeException("Fetch data from another data holder failover logic is not implemented yet!")
   }
 
@@ -150,7 +150,7 @@ class DataHolder(publicHostname: String) extends Actor with ActorLogging {
       context.become(receivedData(originalSender, data))
 
     case Failure(cause) =>
-      log.error(s"Error processing fetch data request: $cause. Trying again.")
+      log.error("Error processing fetch data request: {}. Trying again.", cause)
       import context.dispatcher
       context.system.scheduler.scheduleOnce(
         2 second,
@@ -183,14 +183,14 @@ class DataHolder(publicHostname: String) extends Actor with ActorLogging {
       sender ! SidechannelAddress(InetSocketAddress.createUnresolved(publicHostname, boundPort))
 
     case GetDataRef =>
-      log.info(s"Serving data to ${sender.path}")
+      log.info("Serving data to {}", sender.path)
       sender ! DataRef(relation)
   }
 
   def withCommonNotReady(block: Receive): Receive = {
     val commonNotReady: Receive = {
       case GetDataRef | GetSidechannelAddress =>
-        log.warning(s"Request to serve data from uninitialized $name")
+        log.warning("Request to serve data from uninitialized {}", name)
         sender ! DataNotReady
     }
 

--- a/src/main/scala/com/github/codelionx/dodo/actors/Reaper.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/Reaper.scala
@@ -36,7 +36,7 @@ class Reaper extends Actor with ActorLogging {
 
   override def postStop(): Unit = {
     super.postStop()
-    log.info("Stopped {}", self.path)
+    log.info("Stopped reaper")
   }
 
   override def receive: Receive = {
@@ -49,10 +49,11 @@ class Reaper extends Actor with ActorLogging {
       if (watched.isEmpty) terminateSystem()
 
     case unexpected =>
-      log.error(s"ERROR: Unknown message: $unexpected")
+      log.error("ERROR: Unknown message: {}", unexpected)
   }
 
   def terminateSystem(): Unit = {
+    log.info("Terminating system as all actors died.")
     context.system.terminate()
   }
 }

--- a/src/main/scala/com/github/codelionx/dodo/actors/Reaper.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/Reaper.scala
@@ -29,15 +29,11 @@ class Reaper extends Actor with ActorLogging {
 
   val watched: ArrayBuffer[ActorRef] = ArrayBuffer.empty[ActorRef]
 
-  override def preStart(): Unit = {
-    super.preStart()
-    log.info("Started reaper at {}", self.path)
-  }
+  override def preStart(): Unit =
+    log.info("Started {} at {}", name, self.path)
 
-  override def postStop(): Unit = {
-    super.postStop()
-    log.info("Stopped reaper")
-  }
+  override def postStop(): Unit =
+    log.info("Stopped {}", name)
 
   override def receive: Receive = {
     case WatchMe(ref) =>
@@ -49,7 +45,7 @@ class Reaper extends Actor with ActorLogging {
       if (watched.isEmpty) terminateSystem()
 
     case unexpected =>
-      log.error("ERROR: Unknown message: {}", unexpected)
+      log.error("Unknown message: {}", unexpected)
   }
 
   def terminateSystem(): Unit = {

--- a/src/main/scala/com/github/codelionx/dodo/actors/ResultCollector.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ResultCollector.scala
@@ -77,10 +77,13 @@ class ResultCollector extends Actor with ActorLogging {
     case _ => log.info("Unknown message received")
   }
 
-  def write(message: String): Unit = {
-    bw.write(message + "\n")
-    log.info(message)
-  }
+  def write(message: String): Unit =
+    if (settings.outputToConsole) {
+      bw.write(message + "\n")
+      log.info(message)
+    } else {
+      bw.write(message + "\n")
+    }
 
   def prettyList(l: Seq[String]): String = {
     val newString: StringBuilder = new StringBuilder()

--- a/src/main/scala/com/github/codelionx/dodo/actors/ResultCollector.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ResultCollector.scala
@@ -33,15 +33,12 @@ class ResultCollector extends Actor with ActorLogging {
   // FileWriter
   val bw = new BufferedWriter(new FileWriter(new File(settings.outputFilePath)))
 
-  override def preStart(): Unit = {
-    log.info(s"Starting $name")
+  override def preStart(): Unit =
     Reaper.watchWithDefault(self)
-  }
 
   override def postStop(): Unit = {
     bw.close()
-    log.info(s"$odsFound ODs found")
-    log.info(s"Stopping $name")
+    log.info("{} ODs found", odsFound)
   }
 
   override def receive: Receive = {

--- a/src/main/scala/com/github/codelionx/dodo/actors/ResultCollector.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ResultCollector.scala
@@ -74,13 +74,11 @@ class ResultCollector extends Actor with ActorLogging {
     case _ => log.info("Unknown message received")
   }
 
-  def write(message: String): Unit =
-    if (settings.outputToConsole) {
-      bw.write(message + "\n")
+  def write(message: String): Unit = {
+    bw.write(message + "\n")
+    if (settings.outputToConsole)
       log.info(message)
-    } else {
-      bw.write(message + "\n")
-    }
+  }
 
   def prettyList(l: Seq[String]): String = {
     val newString: StringBuilder = new StringBuilder()

--- a/src/main/scala/com/github/codelionx/dodo/actors/SystemCoordinator.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/SystemCoordinator.scala
@@ -63,7 +63,7 @@ class SystemCoordinator extends Actor with ActorLogging with DependencyChecking 
       startTime = LocalDateTime.now()
       startNanos = System.nanoTime()
 
-      log.info(s"Session is in the hand of ${ODMaster.name}")
+      log.info("Session is in the hand of {}", ODMaster.name)
       odMaster ! FindODs(dataHolder)
 
     case Finished =>

--- a/src/main/scala/com/github/codelionx/dodo/actors/Worker.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/Worker.scala
@@ -31,7 +31,7 @@ object Worker {
   case class ODFound(od: (Seq[Int], Seq[Int]))
 
   // debugging
-  private val reportingInterval = 5 seconds
+  val reportingInterval: FiniteDuration = 5 seconds
 
   private case object ReportStatus
 
@@ -69,11 +69,11 @@ class Worker(resultCollector: ActorRef) extends Actor with ActorLogging with Dep
     case DataRef(table) =>
       sender ! GetTask
       context.become(workReady(table))
-    case _ => log.info("Unknown message received")
 
     case ReportStatus =>
       log.debug("Worker uninitialized, waiting for data ref...")
 
+    case _ => log.info("Unknown message received")
   }
 
   def workReady(table: Array[TypedColumn[Any]]): Receive = {
@@ -117,9 +117,9 @@ class Worker(resultCollector: ActorRef) extends Actor with ActorLogging with Dep
 
     case ReportStatus =>
       val statusMsg = itemsProcessed match {
-        case i if i > 1000 * 1000 * 1000 => s"${i / 1000 / 1000 / 1000}M"
-        case i if i > 1000 * 1000 => s"${i / 1000 / 1000}M"
-        case i if i > 1000 => s"${i / 1000}k"
+        case i if i > 10e9 => s"${i / 10e9}B"
+        case i if i > 10e6 => s"${i / 10e6}M"
+        case i if i > 10e3 => s"${i / 10e3}k"
         case i => i
       }
       log.debug("Processed {} items", statusMsg)


### PR DESCRIPTION
### Proposed Changes

- add debug logging
- use log string construction provided by logging framework
  - increases performance as the strings are only built if the log level is enabled
- write our logs to their own file for easier debugging
- let workers output their processed items in a regular interval if `DEBUG`-level is enabled
- let `ResultCollector` not print results to console per default (can be enabled via a setting now)
- one can use `akka.loglevel` in `application.conf` to configure the logging level

### Type of Changes

- [ ] Feature
- [ ] Bug fix
- [x] Refactoring

