### PR TITLE
Fix work distribution from master to workers

### DIFF
--- a/src/main/scala/com/github/codelionx/dodo/actors/ODMaster.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/ODMaster.scala
@@ -114,12 +114,12 @@ class ODMaster(nWorkers: Int, resultCollector: ActorRef, systemCoordinator: Acto
         log.info("Generating first candidates and starting search")
         odsToCheck ++= generateFirstCandidates(reducedColumns)
 
-        // sending work to idleWorkers
         if (odsToCheck.isEmpty) {
           log.error("No OCD candidates generated!")
           systemCoordinator ! Finished
 
-        } else {
+        } else if (idleWorkers.nonEmpty) {
+          // sending work to idleWorkers
           val queueLength = odsToCheck.length
           val workers = idleWorkers.length
           val batchLength = math.min(

--- a/src/main/scala/com/github/codelionx/dodo/actors/Worker.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/Worker.scala
@@ -1,6 +1,6 @@
 package com.github.codelionx.dodo.actors
 
-import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props}
+import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import com.github.codelionx.dodo.Settings
 import com.github.codelionx.dodo.actors.DataHolder.DataRef
 import com.github.codelionx.dodo.actors.ResultCollector.Results
@@ -29,8 +29,6 @@ object Worker {
   case class ODsToCheck(parentODs: Queue[(Seq[Int], Seq[Int])], newODs: Queue[(Seq[Int], Seq[Int])])
 
   case class ODFound(od: (Seq[Int], Seq[Int]))
-
-  case class GetTaskTimeout(master: ActorRef)
 
   // debugging
   val reportingInterval: FiniteDuration = 5 seconds
@@ -81,7 +79,6 @@ class Worker(resultCollector: ActorRef) extends Actor with ActorLogging with Dep
       sender ! OrderEquivalent(oeToCheck, checkOrderEquivalent(table(oeToCheck._1), table(oeToCheck._2)))
       sender ! GetTask
       itemsProcessed += 1
-      context.become(workReady(table))
 
     case CheckForOD(odCandidates, reducedColumns) =>
       var newCandidates: Queue[(Seq[Int], Seq[Int])] = Queue.empty
@@ -115,7 +112,6 @@ class Worker(resultCollector: ActorRef) extends Actor with ActorLogging with Dep
       itemsProcessed += odCandidates.length
       sender ! ODsToCheck(odCandidates, newCandidates)
       sender ! GetTask
-      context.become(workReady(table))
 
     case ReportStatus =>
       val statusMsg = itemsProcessed match {


### PR DESCRIPTION
### Proposed Changes

- the master now stores references to idle workers if he was not able to send them work
- if new tasks are available it is first scheduled to idle workers, then to regular `GetTask` calls
- this fixes the issue that only one worker gets tasks from the master

### Type of Changes

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring

### Related

- depends on #44 (**merged**) to be merged first
