### PR TITLE
Fix work stealing ACKs and work recovery

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -29,6 +29,7 @@ akka {
   remote {
     artery {
       enabled = on
+      transport = tcp
       canonical.hostname = "127.0.0.1"
       canonical.port = 7877
 
@@ -63,7 +64,7 @@ akka {
 # logging
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
-  loglevel = "INFO"
+  loglevel = "DEBUG"
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 }
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -29,7 +29,7 @@ akka {
   remote {
     artery {
       enabled = on
-      transport = tcp
+      transport = tcp # prefer tcp over aeron-udp
       canonical.hostname = "127.0.0.1"
       canonical.port = 7877
 


### PR DESCRIPTION
### Proposed Changes

Implement protocol according to:

1. Watch actor ref of thief in sender
2. Send work over
3. If ACK received de-watch thief
4. If `Terminated` received, recover work to own queue
5. Use `akka.actor.remote.artery.transport = tcp` as transport configuration

see [Meeting notes from 2019-06-25](https://github.com/CodeLionX/dODo/blob/doc/minutes/doc/minutes/2019-06-25_seminar_meeting.md#how-to-ensure-work-stealing-worked)

### Type of Changes

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring

### Related

- fixes #51
