### PR TITLE
Fix date parsing

### DIFF
--- a/src/main/scala/com/github/codelionx/dodo/types/DateFormat.scala
+++ b/src/main/scala/com/github/codelionx/dodo/types/DateFormat.scala
@@ -1,6 +1,7 @@
 package com.github.codelionx.dodo.types
 
-import java.time.format.DateTimeFormatter
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
+import java.util.Locale
 
 
 /**
@@ -18,12 +19,17 @@ object DateFormat {
   /**
     * Supported date formats (without time info).
     */
-  val dateFormats: Seq[DateFormat] = Seq(IsoDateFormat, BasicFormat, IsoLocalDateFormat)
+  val dateFormats: Seq[DateFormat] = Seq(CustomUSDateFormat, IsoDateFormat, /*BasicFormat,*/ IsoLocalDateFormat)
 
   /**
     * Default date time format.
     */
-  val DEFAULT: DateFormat = BasicFormat
+  val DEFAULT: DateFormat = IsoDateTimeFormat
+
+  // custom formatters
+  private val customUSDateFormatter = new DateTimeFormatterBuilder()
+    .appendPattern("MM/dd/yyyy")
+    .toFormatter(Locale.US)
 
   /**
     * Backward mapping from a [[java.time.format.DateTimeFormatter]] to the DateFormat.
@@ -31,11 +37,12 @@ object DateFormat {
     * @return a [[com.github.codelionx.dodo.types.DateFormat]] marker object that represents the supplied `formatter`.
     */
   def apply(formatter: DateTimeFormatter): DateFormat = formatter match {
-    case DateTimeFormatter.BASIC_ISO_DATE => BasicFormat
+//    case DateTimeFormatter.BASIC_ISO_DATE => BasicFormat
     case DateTimeFormatter.ISO_DATE_TIME => IsoDateTimeFormat
     case DateTimeFormatter.ISO_DATE => IsoDateFormat
     case DateTimeFormatter.ISO_LOCAL_DATE => IsoLocalDateFormat
     case DateTimeFormatter.RFC_1123_DATE_TIME => RFC_1123_Format
+    case `customUSDateFormatter`=> CustomUSDateFormat
     case f => throw new IllegalArgumentException(s"The specified formatter is not supported: $f")
   }
 
@@ -45,11 +52,12 @@ object DateFormat {
     * @return the corresponding formatter
     */
   def toFormatter(dateFormat: DateFormat): DateTimeFormatter = dateFormat match {
-    case BasicFormat => DateTimeFormatter.BASIC_ISO_DATE
+//    case BasicFormat => DateTimeFormatter.BASIC_ISO_DATE
     case IsoDateTimeFormat => DateTimeFormatter.ISO_DATE_TIME
     case IsoDateFormat => DateTimeFormatter.ISO_DATE
     case IsoLocalDateFormat => DateTimeFormatter.ISO_LOCAL_DATE
     case RFC_1123_Format => DateTimeFormatter.RFC_1123_DATE_TIME
+    case CustomUSDateFormat => customUSDateFormatter
   }
 
   implicit class ConvertableDateFormat(dateFormat: DateFormat) {
@@ -72,8 +80,9 @@ object DateFormat {
   */
 sealed trait DateFormat extends Serializable
 
-case object BasicFormat extends DateFormat
+//case object BasicFormat extends DateFormat
 case object IsoDateTimeFormat extends DateFormat
 case object IsoDateFormat extends DateFormat
 case object IsoLocalDateFormat extends DateFormat
 case object RFC_1123_Format extends DateFormat
+case object CustomUSDateFormat extends DateFormat

--- a/src/test/scala/com/github/codelionx/dodo/parsing/TypeInferrerSpec.scala
+++ b/src/test/scala/com/github/codelionx/dodo/parsing/TypeInferrerSpec.scala
@@ -24,9 +24,9 @@ class TypeInferrerSpec extends WordSpec with Matchers {
     }
 
     "infer datetimes with time zone" in {
-      TypeInferrer.inferType("2019-12-27T22:15:30+02:00").shouldEqual(ZonedDateType(IsoDateTimeFormat))
-      TypeInferrer.inferType("Tue, 3 Jun 2008 11:05:30 GMT").shouldEqual(ZonedDateType(RFC_1123_Format))
-      TypeInferrer.inferType("10 Jun 2019 08:05:30 GMT").shouldEqual(ZonedDateType(RFC_1123_Format))
+      TypeInferrer.inferType("2019-12-27T22:15:30+02:00").shouldEqual(ZonedDateTimeType(IsoDateTimeFormat))
+      TypeInferrer.inferType("Tue, 3 Jun 2008 11:05:30 GMT").shouldEqual(ZonedDateTimeType(RFC_1123_Format))
+      TypeInferrer.inferType("10 Jun 2019 08:05:30 GMT").shouldEqual(ZonedDateTimeType(RFC_1123_Format))
     }
 
     "infer dates" in {

--- a/src/test/scala/com/github/codelionx/dodo/parsing/TypeInferrerSpec.scala
+++ b/src/test/scala/com/github/codelionx/dodo/parsing/TypeInferrerSpec.scala
@@ -51,5 +51,9 @@ class TypeInferrerSpec extends WordSpec with Matchers {
     "not infer 0-padded number with 6 digits as date" in {
       TypeInferrer.inferType("000023").shouldEqual(LongType)
     }
+
+    "not infer 0-padded number with 8 digits as date" in {
+      TypeInferrer.inferType("00000023").shouldEqual(LongType)
+    }
   }
 }

--- a/src/test/scala/com/github/codelionx/dodo/parsing/TypeInferrerSpec.scala
+++ b/src/test/scala/com/github/codelionx/dodo/parsing/TypeInferrerSpec.scala
@@ -18,22 +18,21 @@ class TypeInferrerSpec extends WordSpec with Matchers {
       TypeInferrer.inferType(Long.MaxValue.toString).shouldEqual(LongType)
     }
 
-    "infer datetimes without time zone" in {
-      TypeInferrer.inferType("2011-12-03T10:15:30").shouldEqual(LocalDateType(IsoDateTimeFormat))
-
-    }
-
     "infer datetimes with time zone" in {
       TypeInferrer.inferType("2019-12-27T22:15:30+02:00").shouldEqual(ZonedDateTimeType(IsoDateTimeFormat))
       TypeInferrer.inferType("Tue, 3 Jun 2008 11:05:30 GMT").shouldEqual(ZonedDateTimeType(RFC_1123_Format))
       TypeInferrer.inferType("10 Jun 2019 08:05:30 GMT").shouldEqual(ZonedDateTimeType(RFC_1123_Format))
     }
 
+    "infer datetimes without time zone" in {
+      TypeInferrer.inferType("2011-12-03T10:15:30").shouldEqual(LocalDateTimeType(IsoDateTimeFormat))
+    }
+
     "infer dates" in {
       // dates are always local (without zone)
       TypeInferrer.inferType("2011-12-03").shouldEqual(LocalDateType(IsoDateFormat))
       TypeInferrer.inferType("2011-12-03+01:00").shouldEqual(LocalDateType(IsoDateFormat))
-      TypeInferrer.inferType("20111203").shouldEqual(LocalDateType(BasicFormat))
+      TypeInferrer.inferType("01/28/1997").shouldEqual(LocalDateType(CustomUSDateFormat))
     }
 
     "infer strings" in {
@@ -46,6 +45,11 @@ class TypeInferrerSpec extends WordSpec with Matchers {
       TypeInferrer.inferType("").shouldEqual(NullType)
       TypeInferrer.inferType("null").shouldEqual(NullType)
       TypeInferrer.inferType("?").shouldEqual(NullType)
+    }
+
+    // bugfix guides
+    "not infer 0-padded number with 6 digits as date" in {
+      TypeInferrer.inferType("000023").shouldEqual(LongType)
     }
   }
 }

--- a/src/test/scala/com/github/codelionx/dodo/types/DataTypeSpec.scala
+++ b/src/test/scala/com/github/codelionx/dodo/types/DataTypeSpec.scala
@@ -1,6 +1,6 @@
 package com.github.codelionx.dodo.types
 
-import java.time.{LocalDateTime, ZonedDateTime}
+import java.time.{LocalDate, LocalDateTime, ZonedDateTime}
 
 import org.scalatest.{Matchers, WordSpec}
 
@@ -16,6 +16,11 @@ class DataTypeSpec extends WordSpec with Matchers {
 
     "support LocalDateTime in the factory method" in {
       val dt = DataType.of[LocalDateTime]
+      dt shouldEqual LocalDateTimeType(DateFormat.DEFAULT)
+    }
+
+    "support LocalDate in the factory method" in {
+      val dt = DataType.of[LocalDate]
       dt shouldEqual LocalDateType(DateFormat.DEFAULT)
     }
 

--- a/src/test/scala/com/github/codelionx/dodo/types/DataTypeSpec.scala
+++ b/src/test/scala/com/github/codelionx/dodo/types/DataTypeSpec.scala
@@ -11,7 +11,7 @@ class DataTypeSpec extends WordSpec with Matchers {
 
     "support ZonedDateTime in the factory method" in {
       val dt = DataType.of[ZonedDateTime]
-      dt shouldEqual ZonedDateType(DateFormat.DEFAULT)
+      dt shouldEqual ZonedDateTimeType(DateFormat.DEFAULT)
     }
 
     "support LocalDateTime in the factory method" in {


### PR DESCRIPTION
### Proposed Changes

- Do not parse `00820192` (numbers of length 8) as dates
- Add format option for US dates: `MM/dd/yyyy`
- Correctly parse dates without time information

### Type of Changes

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring
