### PR TITLE
Improve state sync

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -22,6 +22,9 @@ com.github.codelionx.dodo {
   // print only some found OCDs for better comparability to ocddiscover
   ocd-comparability = true
 
+  // interval for state replication across nodes
+  replication-interval = "20s"
+
   parsing {
     // number of rows to parse before the type inferrer decides on a fixed data type for each column
     inferring-rows = 1000

--- a/src/main/scala/com/github/codelionx/dodo/Settings.scala
+++ b/src/main/scala/com/github/codelionx/dodo/Settings.scala
@@ -4,6 +4,8 @@ import akka.actor.{ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvi
 import com.github.codelionx.dodo.Settings.{ParsingSettings, SideChannelSettings}
 import com.typesafe.config.Config
 
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
 
 object Settings extends ExtensionId[Settings] with ExtensionIdProvider {
 
@@ -59,6 +61,10 @@ class Settings(config: Config) extends Extension {
   val maxBatchSize: Int = config.getInt(s"$namespace.max-batch-size")
 
   val ocdComparability: Boolean = config.getBoolean(s"$namespace.ocd-comparability")
+
+  val stateReplicationInterval: FiniteDuration = Duration.fromNanos(
+    config.getDuration(s"$namespace.replication-interval").toNanos
+  )
 
   val parsing: ParsingSettings = new ParsingSettings(config, namespace)
 

--- a/src/main/scala/com/github/codelionx/dodo/actors/DataHolder.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/DataHolder.scala
@@ -86,7 +86,7 @@ class DataHolder(clusterListener: ActorRef) extends Actor with ActorLogging {
       }
 
     case FetchDataFromCluster =>
-      log.debug("Request to load data from cluster: searching left neighbour")
+      log.debug("Request to load data from cluster: searching left neighbor")
       clusterListener ! GetLeftNeighbor
       context.become(handleLeftNeighborResults(sender))
   }
@@ -94,7 +94,7 @@ class DataHolder(clusterListener: ActorRef) extends Actor with ActorLogging {
   def handleLeftNeighborResults(originalSender: ActorRef): Receive = withCommonNotReady {
     case LeftNeighbor(address) =>
       val otherDataHolder = context.actorSelection(address / userGuardian / ODMaster.name / name)
-      log.info("Asking left neighbour ({}) for sidechannel ref", otherDataHolder)
+      log.info("Asking left neighbor ({}) for sidechannel ref", otherDataHolder)
       otherDataHolder ! GetSidechannelRef
       context.become(handleFetchDataResult(originalSender, isLeftNB = true))
 
@@ -108,7 +108,7 @@ class DataHolder(clusterListener: ActorRef) extends Actor with ActorLogging {
   def handleRightNeighborResults(originalSender: ActorRef): Receive = withCommonNotReady {
     case RightNeighbor(address) =>
       val otherDataHolder = context.actorSelection(address / userGuardian / ODMaster.name / name)
-      log.info("Asking right neighbour ({}) for sidechannel address", otherDataHolder)
+      log.info("Asking right neighbor ({}) for sidechannel address", otherDataHolder)
       otherDataHolder ! GetSidechannelRef
       context.become(handleFetchDataResult(originalSender, isLeftNB = false))
 

--- a/src/main/scala/com/github/codelionx/dodo/actors/DataHolder.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/DataHolder.scala
@@ -119,7 +119,7 @@ class DataHolder(clusterListener: ActorRef) extends Actor with ActorLogging {
 
   def handleFetchDataResult(originalSender: ActorRef, isLeftNB: Boolean): Receive = withCommonNotReady {
     case SidechannelRef(sourceRef) =>
-      ActorStreamConnector.consumeSourceRefVia(sourceRef, self)
+      ActorStreamConnector.consumeSourceRefOfClassVia(sourceRef, classOf[DataOverStream], self)
       context.become(handleStreamResult(originalSender, isLeftNB))
 
     case DataNotReady if isLeftNB =>

--- a/src/main/scala/com/github/codelionx/dodo/actors/StateReplicator.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/StateReplicator.scala
@@ -24,8 +24,6 @@ object StateReplicator {
 
   case class CurrentState(state: Queue[(Seq[Int], Seq[Int])])
 
-  case class ReplicateState(queue: Queue[(Seq[Int], Seq[Int])], versionNr: Int)
-
   case class StateVersion(failedNode: ActorRef, versionNr: Int)
 }
 
@@ -43,91 +41,98 @@ class StateReplicator(master: ActorRef) extends Actor with ActorLogging {
     Reaper.watchWithDefault(self)
   }
 
-  override def receive: Receive = uninitialized(false, false)
+  override def receive: Receive = uninitialized(foundRightNeighbor = false, foundLeftNeighbor = false)
 
-  def uninitialized(foundRightNeighbour: Boolean, foundLeftNeighbour: Boolean): Receive = {
-    case LeftNeighborRef(leftNeighbour) =>
-      leftNode = leftNeighbour
-      if (foundRightNeighbour) {
-        startReplication()
-      } else {
-        context.become(uninitialized(foundRightNeighbour, true))
-      }
+  def uninitialized(foundRightNeighbor: Boolean, foundLeftNeighbor: Boolean): Receive =
+    stateRecoveryHandling orElse
+    stateReceptionHandling orElse {
+      case LeftNeighborRef(leftNeighbor) =>
+        leftReplicator = leftNeighbor
+        if (foundRightNeighbor) {
+          startReplication()
+        } else {
+          context.become(uninitialized(foundRightNeighbor, foundLeftNeighbor = true))
+        }
 
-    case RightNeighborRef(rightNeighbour) =>
-      rightNode = rightNeighbour
-      if (foundLeftNeighbour) {
-        startReplication()
-      } else {
-        context.become(uninitialized(true, foundLeftNeighbour))
+      case RightNeighborRef(rightNeighbor) =>
+        rightReplicator = rightNeighbor
+        if (foundLeftNeighbor) {
+          startReplication()
+        } else {
+          context.become(uninitialized(foundRightNeighbor = true, foundLeftNeighbor))
+        }
+
+      case akka.actor.Status.Failure(error) =>
+        log.error("Could not find neighbor, because", error)
+    }
+
+  def initialized(): Receive =
+    stateRecoveryHandling orElse
+    stateReceptionHandling orElse {
+      case CurrentState(state) =>
+        sendStateViaStream(leftReplicator, state)
+        sendStateViaStream(rightReplicator, state)
+
+      case LeftNeighborRef(newNeighbour) =>
+        updateLeftNeighbor(newNeighbour)
+
+      case RightNeighborRef(newNeighbour) =>
+        updateRightNeighbor(newNeighbour)
+
+      case LeftNeighborDown(newNeighbour) =>
+        sendStateVersionTo(leftReplicator, newNeighbour)
+        leftReplicator = newNeighbour
+
+      case RightNeighborDown(newNeighbour) =>
+        sendStateVersionTo(rightReplicator, newNeighbour)
+        rightReplicator = newNeighbour
+    }
+
+  def stateRecoveryHandling: Receive = {
+    case StateVersion(failedNode, versionNr) =>
+      log.info("{} has version {} of {}'s state.", sender.path, versionNr, failedNode.path)
+      if (neighborStates.contains(failedNode)) {
+        if (neighborStates(failedNode)._2 > versionNr) {
+          log.info("Using my version of {}'s state", failedNode.path)
+          master ! NewODCandidates(neighborStates(failedNode)._1)
+        }
+        neighborStates -= failedNode
       }
   }
 
-  def initialized(): Receive = {
-    case CurrentState(state) =>
-      replicateStateViaStream(state)
-
-    case ReplicateState(state, versionNr) =>
-      updateNeighboursState(sender, state, versionNr)
-
-    case LeftNeighborRef(newNeighbour) =>
-      updateLeftNeighbour(newNeighbour)
-
-    case RightNeighborRef(newNeighbour) =>
-      updateRightNeighbour(newNeighbour)
-
-    case LeftNeighborDown(newNeighbour) =>
-      log.info("Left neighbour {} down. Comparing version with {}.", leftNode.path, newNeighbour.path)
-      if (neighbourStates.contains(leftNode)) {
-        newNeighbour ! StateVersion(leftNode, neighbourStates(leftNode)._2)
-        log.info("My current state for {} is {}", leftNode.path, neighbourStates(leftNode)._2)
-      } else {
-        newNeighbour ! StateVersion(leftNode, -1)
-        log.info("I do not have a state for {}", leftNode.path)
-      }
-      leftNode = newNeighbour
-
-    case RightNeighborDown(newNeighbour) =>
-      log.info("Right neighbour {} down. Comparing version with {}.", rightNode.path, newNeighbour.path)
-      if (neighbourStates.contains(rightNode)) {
-        newNeighbour ! StateVersion(rightNode, neighbourStates(rightNode)._2)
-        log.info("My current state for {} is {}", rightNode.path, neighbourStates(rightNode)._2)
-      } else {
-        newNeighbour ! StateVersion(rightNode, -1)
-        log.info("I do not have a state for {}", rightNode.path)
-      }
-      rightNode = newNeighbour
-
-    case StateVersion(failedNode, versionNr) =>
-      log.info("{} has version {} of {}'s state.", sender.path, versionNr, failedNode.path)
-      if (neighbourStates.contains(failedNode)) {
-        if (neighbourStates(failedNode)._2 > versionNr) {
-          log.info("Using my version of {}'s state", failedNode.path)
-          master ! NewODCandidates(neighbourStates(failedNode)._1)
-        }
-        neighbourStates -= failedNode
-      }
-
+  def stateReceptionHandling: Receive = {
     case SidechannelRef(sourceRef) =>
       log.debug("Receiving state over sidechannel from {}", sender)
       ActorStreamConnector.consumeSourceRefOfClassVia(sourceRef, classOf[StateOverStream], self)
 
+    case StreamInit =>
+      sender ! StreamACK
+
     case stateMessage: StateOverStream =>
-      log.debug("Received data over stream from {}.", stateMessage.data._1.path)
-      updateNeighboursState(stateMessage.data._1, stateMessage.data._2, stateMessage.data._3)
+      val (owner, state, version) = stateMessage.data
+      log.debug("Received data over stream from {}.", owner.path)
+      updateNeighborState(owner, state, version)
       sender ! StreamACK
 
     case StreamComplete =>
-      log.debug("Stream completed!", name)
-      sender ! StreamACK
-
-    case StreamInit =>
+      log.debug("{} completed stream.", name)
       sender ! StreamACK
   }
 
-  def replicateStateViaStream(currentState: Queue[(Seq[Int], Seq[Int])]): Unit = {
-    sendStateViaStream(leftNode, currentState)
-    sendStateViaStream(rightNode, currentState)
+  def sendStateVersionTo(lostReplicator: ActorRef, newNeighbor: ActorRef): Unit = {
+    log.info(
+      "{} neighbor {} down. Comparing version with {}.",
+      if(lostReplicator == leftReplicator) "Left" else "Right",
+      lostReplicator.path,
+      newNeighbor.path
+    )
+    if (neighborStates.contains(lostReplicator)) {
+      newNeighbor ! StateVersion(lostReplicator, neighborStates(lostReplicator)._2)
+      log.info("My current state for {} is {}", lostReplicator.path, neighborStates(lostReplicator)._2)
+    } else {
+      newNeighbor ! StateVersion(lostReplicator, -1)
+      log.info("I do not have a state for {}", lostReplicator.path)
+    }
   }
 
   def sendStateViaStream(receiver: ActorRef, currentState: Queue[(Seq[Int], Seq[Int])]): Unit = {
@@ -139,30 +144,30 @@ class StateReplicator(master: ActorRef) extends Actor with ActorLogging {
     stateVersion += 1
   }
 
-  def updateLeftNeighbour(newNeighbour: ActorRef): Unit = {
-    log.info("Setting {} as my left neighbour", newNeighbour.path)
-    if (neighbourStates.contains(leftNode)) {
-      neighbourStates -= leftNode
+  def updateLeftNeighbor(newNeighbour: ActorRef): Unit = {
+    log.info("Setting {} as my left neighbor", newNeighbour.path)
+    if (neighborStates.contains(leftReplicator)) {
+      neighborStates -= leftReplicator
     }
-    leftNode = newNeighbour
+    leftReplicator = newNeighbour
   }
 
-  def updateRightNeighbour(newNeighbour: ActorRef): Unit = {
-    log.info("Setting {} as my right neighbour", newNeighbour.path)
-    if (neighbourStates.contains(rightNode)) {
-      neighbourStates -= rightNode
+  def updateRightNeighbor(newNeighbour: ActorRef): Unit = {
+    log.info("Setting {} as my right neighbor", newNeighbour.path)
+    if (neighborStates.contains(rightReplicator)) {
+      neighborStates -= rightReplicator
     }
-    rightNode = newNeighbour
+    rightReplicator = newNeighbour
   }
 
-  def updateNeighboursState(neighbour: ActorRef, state: Queue[(Seq[Int], Seq[Int])], versionNr: Int): Unit = {
-    if (neighbourStates.contains(neighbour) && neighbourStates(neighbour)._2 < versionNr) {
-      neighbourStates(neighbour) = (state, versionNr)
+  def updateNeighborState(neighbor: ActorRef, state: Queue[(Seq[Int], Seq[Int])], versionNr: Int): Unit = {
+    if (neighborStates.contains(neighbor) && neighborStates(neighbor)._2 < versionNr) {
+      neighborStates(neighbor) = (state, versionNr)
     } else {
-      neighbourStates += neighbour -> (state, versionNr)
+      neighborStates += neighbor -> (state, versionNr)
     }
-    log.info("Received state with version Nr {} from {}", versionNr, neighbour.path)
-    log.debug("Currently holding states of {}", neighbourStates.keys)
+    log.info("Received state with version Nr {} from {}", versionNr, neighbor.path)
+    log.debug("Currently holding states of {}", neighborStates.keys)
   }
 
   def startReplication(): Unit = {

--- a/src/main/scala/com/github/codelionx/dodo/actors/StateReplicator.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/StateReplicator.scala
@@ -110,7 +110,7 @@ class StateReplicator(master: ActorRef) extends Actor with ActorLogging {
 
     case SidechannelRef(sourceRef) =>
       log.debug("Receiving state over sidechannel from {}", sender)
-      ActorStreamConnector.consumeStateRefVia(sourceRef, self)
+      ActorStreamConnector.consumeSourceRefOfClassVia(sourceRef, classOf[StateOverStream], self)
 
     case stateMessage: StateOverStream =>
       log.debug("Received data over stream from {}.", stateMessage.data._1.path)
@@ -133,7 +133,7 @@ class StateReplicator(master: ActorRef) extends Actor with ActorLogging {
   def sendStateViaStream(receiver: ActorRef, currentState: Queue[(Seq[Int], Seq[Int])]): Unit = {
     log.info("Sending state via sidechannel to {}", receiver)
     val versionedState = (self, currentState, stateVersion)
-    val state = ActorStreamConnector.prepareStateRef(versionedState)
+    val state = ActorStreamConnector.prepareSourceRef(versionedState)
     import context.dispatcher
     state pipeTo receiver
     stateVersion += 1

--- a/src/main/scala/com/github/codelionx/dodo/actors/master/ODCandidateQueue.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/master/ODCandidateQueue.scala
@@ -193,7 +193,7 @@ class ODCandidateQueue private(
     * merges the pending and working queues to send to other masters during state replication
     */
   def shareableState(): Queue[ODCandidate] = {
-    val merged = (pendingOdCandidates.map(_._2).flatten ++ toBeStolenOdCandidates.map(_._2).flatten ++ odCandidates).toList
+    val merged = (pendingOdCandidates.values.flatten ++ toBeStolenOdCandidates.values.flatten ++ odCandidates).toList
     scala.collection.immutable.Queue(merged: _*)
   }
 }

--- a/src/main/scala/com/github/codelionx/dodo/sidechannel/ActorStreamConnector.scala
+++ b/src/main/scala/com/github/codelionx/dodo/sidechannel/ActorStreamConnector.scala
@@ -7,10 +7,8 @@ import akka.stream.{ActorMaterializer, SourceRef}
 import akka.util.ByteString
 import com.github.codelionx.dodo.DodoException
 import com.github.codelionx.dodo.actors.DataHolder.SidechannelRef
-import com.github.codelionx.dodo.sidechannel.StreamedDataExchangeProtocol.{DataOverStream, StateOverStream, StreamACK, StreamComplete, StreamInit}
-import com.github.codelionx.dodo.types.TypedColumn
+import com.github.codelionx.dodo.sidechannel.StreamedDataExchangeProtocol._
 
-import scala.collection.immutable.Queue
 import scala.concurrent.Future
 
 
@@ -20,19 +18,22 @@ object ActorStreamConnector {
 
   /**
     * Creates a [[akka.stream.SourceRef]] containing the `data` (wrapped in a
-    * [[com.github.codelionx.dodo.sidechannel.StreamedDataExchangeProtocol.DataOverStream]] message,
+    * [[com.github.codelionx.dodo.sidechannel.StreamedDataExchangeProtocol.OverStream]] message,
     * serialized, chunked, and framed) and wraps it inside
     * a [[com.github.codelionx.dodo.actors.DataHolder.SidechannelRef]]. The returned future can be piped to another
     * actor reference (possibly on another node). See [[akka.pattern.pipe]].
+    *
+    * @see [[com.github.codelionx.dodo.sidechannel.StreamedDataExchangeProtocol.OverStreamCompanion]] for enhancing this
+    *     functionality
     */
-  def prepareSourceRef(data: Array[TypedColumn[Any]])(implicit context: ActorContext): Future[SidechannelRef] = {
+  def prepareSourceRef[T: OverStreamCompanion](data: T)(implicit context: ActorContext): Future[SidechannelRef] = {
     val system: ActorSystem = context.system
     val serialization = SerializationExtension(system)
     import system.dispatcher
     implicit val mat: ActorMaterializer = ActorMaterializer()(context)
 
     Source.single(data)
-      .map(DataOverStream)
+      .map(data => OverStreamCompanion(data))
       .map(serialization.serialize)
       .map {
         case scala.util.Success(msg) => ByteString.fromArray(msg)
@@ -48,12 +49,12 @@ object ActorStreamConnector {
 
   /**
     * Takes a [[akka.stream.SourceRef]] and processes it by sending it to the supplied `actorRef`.
-    * The data is decoded, aggregated and deserialized to the
-    * [[com.github.codelionx.dodo.sidechannel.StreamedDataExchangeProtocol.DataOverStream]] message. See
+    * The data is decoded, aggregated and deserialized to the supplied
+    * [[com.github.codelionx.dodo.sidechannel.StreamedDataExchangeProtocol.OverStream]] message. See
     * [[com.github.codelionx.dodo.sidechannel.StreamedDataExchangeProtocol]] for all messages that the supplied actor
     * must handle.
     */
-  def consumeSourceRefVia(source: SourceRef[ByteString], actorRef: ActorRef)(implicit context: ActorContext): Unit = {
+  def consumeSourceRefOfClassVia[T](source: SourceRef[ByteString], msgClass: Class[_ <: OverStream[T]], actorRef: ActorRef)(implicit context: ActorContext): Unit = {
     val system: ActorSystem = context.system
     val serialization = SerializationExtension(system)
     implicit val mat: ActorMaterializer = ActorMaterializer()(context)
@@ -61,64 +62,12 @@ object ActorStreamConnector {
     source
       .via(Framing.simpleFramingProtocolDecoder(frameLength))
       .reduce(_ ++ _)
-      .map(bytes => serialization.deserialize(bytes.toArray, classOf[DataOverStream]))
+      .map(bytes => serialization.deserialize(bytes.toArray, msgClass))
       .map {
         case scala.util.Success(msg) => msg
         case scala.util.Failure(cause) => throw new DodoException("Deserialization of message failed", cause)
       }
       .runWith(Sink.actorRefWithAck(actorRef, StreamInit, StreamACK, StreamComplete))
   }
-
-  /**
-    * Creates a [[akka.stream.SourceRef]] containing the `data` (wrapped in a
-    * [[com.github.codelionx.dodo.sidechannel.StreamedDataExchangeProtocol.StateOverStream]] message,
-    * serialized, chunked, and framed) and wraps it inside
-    * a [[com.github.codelionx.dodo.actors.DataHolder.SidechannelRef]]. The returned future can be piped to another
-    * actor reference (possibly on another node). See [[akka.pattern.pipe]].
-    */
-  def prepareStateRef(data: (ActorRef, Queue[(Seq[Int], Seq[Int])], Int))(implicit context: ActorContext): Future[SidechannelRef] = {
-    val system: ActorSystem = context.system
-    val serialization = SerializationExtension(system)
-    import system.dispatcher
-    implicit val mat: ActorMaterializer = ActorMaterializer()(context)
-
-    Source.single(data)
-      .map(StateOverStream)
-      .map(serialization.serialize)
-      .map {
-        case scala.util.Success(msg) => ByteString.fromArray(msg)
-        case scala.util.Failure(cause) => throw new DodoException("Serialization of message failed", cause)
-      }
-      .flatMapConcat(bytes =>
-        Source.fromIterator(() => bytes.grouped(frameLength))
-      )
-      .via(Framing.simpleFramingProtocolEncoder(frameLength))
-      .runWith(StreamRefs.sourceRef())
-      .map(SidechannelRef)
-  }
-
-  /**
-    * Takes a [[akka.stream.SourceRef]] and processes it by sending it to the supplied `actorRef`.
-    * The data is decoded, aggregated and deserialized to the
-    * [[com.github.codelionx.dodo.sidechannel.StreamedDataExchangeProtocol.StateOverStream]] message. See
-    * [[com.github.codelionx.dodo.sidechannel.StreamedDataExchangeProtocol]] for all messages that the supplied actor
-    * must handle.
-    */
-  def consumeStateRefVia(source: SourceRef[ByteString], actorRef: ActorRef)(implicit context: ActorContext): Unit = {
-    val system: ActorSystem = context.system
-    val serialization = SerializationExtension(system)
-    implicit val mat: ActorMaterializer = ActorMaterializer()(context)
-
-    source
-      .via(Framing.simpleFramingProtocolDecoder(frameLength))
-      .reduce(_ ++ _)
-      .map(bytes => serialization.deserialize(bytes.toArray, classOf[StateOverStream]))
-      .map {
-        case scala.util.Success(msg) => msg
-        case scala.util.Failure(cause) => throw new DodoException("Deserialization of message failed", cause)
-      }
-      .runWith(Sink.actorRefWithAck(actorRef, StreamInit, StreamACK, StreamComplete))
-  }
-
 
 }

--- a/src/main/scala/com/github/codelionx/dodo/sidechannel/StreamedDataExchangeProtocol.scala
+++ b/src/main/scala/com/github/codelionx/dodo/sidechannel/StreamedDataExchangeProtocol.scala
@@ -6,19 +6,74 @@ import com.github.codelionx.dodo.types.TypedColumn
 import scala.collection.immutable.Queue
 
 
-
-
 object StreamedDataExchangeProtocol {
 
   /**
-    * Message that wrappes the relational data. Sent via the stream sidechannel.
+    * Type class for constructing [[com.github.codelionx.dodo.sidechannel.StreamedDataExchangeProtocol.OverStream]]
+    * messages containing different data types.
+    *
+    * @see [[com.github.codelionx.dodo.sidechannel.ActorStreamConnector]]
+    * @tparam T data type that is wrapped by the [[OverStream]] message
     */
-  case class DataOverStream(data: Array[TypedColumn[Any]]) extends Serializable
+  trait OverStreamCompanion[T] {
+
+    def apply(data: T): OverStream[T]
+
+  }
 
   /**
-    * Message that wrappes the current state and version number. Sent via the stream sidechannel.
+    * Companion implementing type class functionality for
+    * [[com.github.codelionx.dodo.sidechannel.StreamedDataExchangeProtocol.OverStreamCompanion]].
+    *
+    * @see [[com.github.codelionx.dodo.sidechannel.StreamedDataExchangeProtocol.OverStreamCompanion]]
     */
-  case class StateOverStream(data: (ActorRef, Queue[(Seq[Int], Seq[Int])], Int)) extends Serializable
+  object OverStreamCompanion {
+
+    def apply[T: OverStreamCompanion](data: T): OverStream[T] = implicitly[OverStreamCompanion[T]].apply(data)
+
+    // implicit instances for the type class
+    implicit def dataOverStream: OverStreamCompanion[Array[TypedColumn[Any]]] = DataOverStream
+
+    implicit def stateOverStream: OverStreamCompanion[(ActorRef, Queue[(Seq[Int], Seq[Int])], Int)] = StateOverStream
+  }
+
+  trait OverStream[T] extends Serializable {
+
+    def data: T
+  }
+
+  object OverStream {
+
+    /**
+      * Syntactic sugar to allow `OverStream.apply()` instead of using `OverStreamCompanion.apply()` to construct
+      * [[OverStream]] messages.
+      */
+    def apply[T: OverStreamCompanion](data: T): OverStream[T] = OverStreamCompanion(data)
+  }
+
+  // dataset message for sidechannel
+  object DataOverStream extends OverStreamCompanion[Array[TypedColumn[Any]]] {
+
+    override def apply(data: Array[TypedColumn[Any]]): DataOverStream = new DataOverStream(data)
+  }
+
+  /**
+    * Message that wraps the relational data. Sent via the stream sidechannel.
+    */
+  class DataOverStream(val data: Array[TypedColumn[Any]])
+    extends OverStream[Array[TypedColumn[Any]]]
+
+  // state message for sidechannel
+  object StateOverStream extends OverStreamCompanion[(ActorRef, Queue[(Seq[Int], Seq[Int])], Int)] {
+
+    override def apply(data: (ActorRef, Queue[(Seq[Int], Seq[Int])], Int)): StateOverStream = new StateOverStream(data)
+  }
+
+  /**
+    * Message that wraps the current state and version number. Sent via the stream sidechannel.
+    */
+  class StateOverStream(val data: (ActorRef, Queue[(Seq[Int], Seq[Int])], Int))
+    extends OverStream[(ActorRef, Queue[(Seq[Int], Seq[Int])], Int)]
 
   /**
     * Indicates stream initialization.
@@ -44,4 +99,5 @@ object StreamedDataExchangeProtocol {
     * <b>Only used internally!</b>
     */
   case object StreamACK
+
 }


### PR DESCRIPTION
### Proposed Changes

- settings key for replication interval
- generalizes `ActorStreamConnector` (reduces code duplication) using a type class for the envelop messages (a.k.a. `OverStream[T]`)
- refactorings of `ClusterListener` and `StateReplicator` (naming, code duplication, conciseness)
- restores consistent message handling in `ODMaster` (every message is handled in every state [besides some exceptions :sweat_smile:])
- `ClusterListener`
  - improves error handling (`akka.actor.status.Failure` is now send to correct actor)
  - puts messages that can not be handled at the current actor state back in the message inbox (with timeout)
  - found bug, where the `RegisterActorRef` messages gets lost in between nodes (pot. because the receiving nodes is not ready yet); fixed temp. by delaying the message
- `StateReplicator`
  - now handles recovery and state synchronization in all actor states