### PR TITLE
Fix work stealing and downing protocol transitions

### DIFF
--- a/src/main/scala/com/github/codelionx/dodo/actors/master/DowningProtocol.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/master/DowningProtocol.scala
@@ -47,7 +47,7 @@ trait DowningProtocol {
       }
 
     case GetWorkloadDowning if sender != self =>
-      val workAvailable = candidateQueue.workAvailable && candidateQueue.hasPendingWork
+      val workAvailable = candidateQueue.workAvailable || candidateQueue.hasPendingWork
       log.info(
         "Responding to downing workload with {} to {}",
         if (workAvailable) "work available" else "no work available",

--- a/src/main/scala/com/github/codelionx/dodo/actors/master/DowningProtocol.scala
+++ b/src/main/scala/com/github/codelionx/dodo/actors/master/DowningProtocol.scala
@@ -62,7 +62,7 @@ trait DowningProtocol {
   }
 
   def startDowningProtocol(): Unit = {
-    log.info("{} started downingProtocol", self.path.name)
+    log.info("{} started downing protocol", self.path.name)
     pendingMasters = Set.empty
     cluster.subscribe(self, classOf[MemberRemoved], classOf[UnreachableMember])
 


### PR DESCRIPTION
### Proposed Changes

- fix downing protocol: it doesn't matter if we have work or pending work --> it still means that we are still working and can not shut down the cluster:
   ```scala
   // val workAvailable = candidateQueue.workAvailable && candidateQueue.hasPendingWork
   // ==>
   val workAvailable = candidateQueue.workAvailable || candidateQueue.hasPendingWork
   ```
- exit work stealing early if we are able to supply a batch to a worker, cache the worker as idle otherwise
- fix work stealing protocol transitions to downing protocol
  - only start downing if we really have no work (even no pending work)
  - exit work stealing if we got work from our own workers during the time we waited for the `WorkloadTimeout`

### Type of Changes

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring

